### PR TITLE
Fix stdio mode writing status message to stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ class OpenMeteoMCPServer {
       const server = this.createServer();
       const transport = new StdioServerTransport();
       server.oninitialized = () => {
-        console.log("✅ MCP server initialized and ready (stdio).");
+        console.error("✅ MCP server initialized and ready (stdio).");
       };
       await server.connect(transport as Transport);
       console.error('✅ Open-Meteo MCP Server running on stdio');


### PR DESCRIPTION
Change console.log to console.error in the oninitialized callback so the status message goes to stderr instead of stdout. MCP servers using stdio transport must only output valid JSON-RPC messages to stdout - any other output breaks the protocol.