### PR TITLE
Update .gitignore and sync package-lock.json Node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ jspm_packages/
 
 # Claude/MCP specific
 .claude/
+.agents/
+.cursor/
 .mcp.json
 
 # IDE files

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
## Summary

Quick maintenance PR to update `.gitignore` and sync `package-lock.json` with the Node.js version requirement.

## Changes

### .gitignore
- ✅ Added `.agents/` (Claude Code agent cache)
- ✅ Added `.cursor/` (Cursor IDE configuration)

### package-lock.json
- ✅ Updated `engines.node` to `>=22.0.0` (matches `package.json`)

## Why

These directories were showing as untracked in `git status` and should be ignored for Claude Code integration. The package-lock.json was out of sync with the Node.js 22 requirement in package.json.

## Testing

- ✅ No functional changes
- ✅ Files correctly ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)