### PR TITLE
Fix Climate Projection API endpoint and update documentation

### DIFF
--- a/.agents/skills/open-meteo/SKILL.md
+++ b/.agents/skills/open-meteo/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: open-meteo
+description: "Integrate Open-Meteo's comprehensive suite of weather APIs: Forecast, Historical, Air Quality, Geocoding, Marine, Flood, Elevation, Climate, Seasonal, and Ensemble models. Enables query design, variable selection, timezone/timeformat/units, multi-location batching, and robust error handling. Keywords: Open-Meteo, Forecast, Historical, Air Quality, Geocoding, Marine, Flood, Elevation, Climate, Seasonal, Ensemble, API, weather, MCP."
+version: "1.5.0"
+release_date: "2026-02-13"
+---
+
+# Open Meteo
+
+## When to use
+
+- You need **weather forecasts** (hourly/daily/current) for any location.
+- You need **historical weather data** for a specific date range.
+- You need **air quality** or **pollen** forecasts.
+- You need to get **geographic coordinates** and timezone from a place name (geocoding).
+- You need specialized data like **marine/wave forecasts**, **river flood data**, **elevation data**, or long-term **seasonal and climate projections**.
+- You need to query specific **weather models** or **ensemble forecasts**.
+- You need a deterministic guide for query parameters, response parsing, and error handling for any Open-Meteo API.
+
+## Goal
+
+Provide a reliable, production-friendly way to call the full range of Open-Meteo APIs, choose variables, control time/units/timezone, and parse responses consistently.
+
+## Steps
+
+1.  **Pick the correct API and base URL**
+
+    -   **Forecast**: `https://api.open-meteo.com/v1/forecast` (and model-specific endpoints like `/v1/gfs`)
+    -   **Historical**: `https://archive-api.open-meteo.com/v1/archive`
+    -   **Air Quality**: `https://air-quality-api.open-meteo.com/v1/air-quality`
+    -   **Geocoding**: `https://geocoding-api.open-meteo.com/v1/search`
+    -   **Marine/Ocean**: `https://marine-api.open-meteo.com/v1/marine`
+    -   **Flood**: `https://flood-api.open-meteo.com/v1/flood`
+    -   **Seasonal**: `https://seasonal-api.open-meteo.com/v1/seasonal`
+    -   **Ensemble**: `https://ensemble-api.open-meteo.com/v1/ensemble`
+    -   **Elevation/Climate**: `https://api.open-meteo.com/v1/elevation` or `/v1/climate`
+
+2.  **Resolve coordinates (if you only have a name)**
+
+    -   Call the Geocoding API (`/v1/search`) with `name` to get `latitude`, `longitude`, and `timezone`.
+
+3.  **Design your time axis**
+
+    -   Use `timezone` (e.g., `auto` or `Europe/Berlin`), which is required for `daily` aggregations.
+    -   Choose `timeformat` (`iso8601` or `unixtime`). Remember `unixtime` is always UTC and requires manual offset calculation for local time.
+    -   Specify a time range using `forecast_days`/`past_days` or `start_date`/`end_date`.
+
+4.  **Choose variables minimally**
+
+    -   Request only the variables you need via `hourly=...`, `daily=...`, etc. to reduce payload size.
+    -   Keep variable names exact; typos will result in a JSON error response.
+
+5.  **Choose units and models deliberately**
+
+    -   Specify units like `temperature_unit`, `wind_speed_unit`, and `precipitation_unit`.
+    -   For forecasts, select specific weather models via the `models=...` parameter or by using a model-specific endpoint (e.g., `/v1/dwd-icon`).
+
+6.  **Implement robust request/response handling**
+
+    -   Handle both HTTP-level errors (e.g., 404, 500) and API-level JSON errors (`{"error": true, "reason": "..."}`).
+    -   If you query for multiple locations (comma-separated coordinates), the JSON response will be a list of objects instead of a single object.
+
+## Best Practices
+
+-   **Check Timezones**: Do not omit `timezone` when requesting `daily` variables.
+-   **Handle `unixtime` Correctly**: Do not assume `unixtime` timestamps are local time; they are GMT+0 and require `utc_offset_seconds` for adjustment.
+-   **Error Handling**: Do not silently ignore `{"error": true}` responses; fail fast with the provided `reason`.
+-   **Minimal Queries**: Do not request huge variable sets by default; keep queries minimal to reduce payload and avoid accidental overuse.
+
+## Definition of done
+
+- You can geocode a place name and obtain coordinates/timezone.
+- You can fetch data for Forecast, Air Quality, and Historical APIs.
+- You can fetch data from at least one other specialized API (e.g., Marine, Flood, Elevation).
+- Your client code handles both HTTP-level failures and JSON-level `error: true` with clear messages.
+- Attribution requirements from the docs are captured for Air Quality (CAMS) and Geocoding (GeoNames).
+
+## Links
+
+-   **Official Docs**:
+    -   [Weather Forecast](https://open-meteo.com/en/docs)
+    -   [Historical Weather](https://open-meteo.com/en/docs/historical-weather-api)
+    -   [Air Quality](https://open-meteo.com/en/docs/air-quality-api)
+    -   [Geocoding](https://open-meteo.com/en/docs/geocoding-api)
+    -   [Marine Weather](https://open-meteo.com/en/docs/marine-weather-api)
+    -   [Flood Forecast](https://open-meteo.com/en/docs/flood-api)
+    -   [Elevation](https://open-meteo.com/en/docs/elevation-api)
+    -   [Climate Projections](https://open-meteo.com/en/docs/climate-api)
+    -   [Ensemble Forecasts](https://open-meteo.com/en/docs/ensemble-api)
+    -   [Seasonal Forecasts](https://open-meteo.com/en/docs/seasonal-forecast-api)
+-   **Skill References**:
+    -   `references/forecast-api.md`
+    -   `references/models.md`
+    -   `references/weather-codes.md`
+    -   `references/air-quality-api.md`
+    -   `references/geocoding-api.md`
+    -   `references/examples.md`
+    -   `references/historical-weather-api.md`
+    -   `references/marine-weather-api.md`
+    -   `references/flood-forecast-api.md`
+    -   `references/elevation-api.md`
+    -   `references/seasonal-forecast-api.md`
+    -   `references/climate-projection-api.md`
+    -   `references/ensemble-forecast-api.md`

--- a/.agents/skills/open-meteo/references/air-quality-api.md
+++ b/.agents/skills/open-meteo/references/air-quality-api.md
@@ -1,0 +1,159 @@
+# Open-Meteo Air Quality API (in-scope)
+
+Source of truth: https://open-meteo.com/en/docs/air-quality-api
+
+## Base URL
+
+- `https://air-quality-api.open-meteo.com/v1/air-quality`
+
+## Core query parameters
+
+### Required
+
+- `latitude` (float)
+- `longitude` (float)
+
+### Variable selection
+
+- `hourly` (string array): comma-separated or repeated `&hourly=` parameters.
+- `current` (string array): current-condition air-quality variables.
+
+### Domain selection
+
+- `domains` (string, default `auto`)
+  - `auto`: combine both domains automatically.
+  - `cams_europe`: European domain.
+  - `cams_global`: global domain.
+
+Docs note: European and global domains are not coupled and may show different forecasts.
+
+### Time controls
+
+- `timezone` (string, default `GMT`)
+  - Supports TZ database names.
+  - `timezone=auto` resolves coordinates to local timezone.
+
+- `timeformat` (string, default `iso8601`)
+  - `iso8601` or `unixtime`.
+  - If `unixtime`: timestamps are GMT+0; apply `utc_offset_seconds` to derive correct local dates.
+
+- `forecast_days` (int 0–7, default 5)
+- `past_days` (int 0–92, default 0)
+
+- Alternative timestep control:
+  - `forecast_hours`, `past_hours`
+
+- Explicit time interval:
+  - `start_date`, `end_date` (YYYY-MM-DD)
+  - `start_hour`, `end_hour` (YYYY-MM-DDThh:mm)
+
+### Grid cell selection
+
+- `cell_selection` (string, default `nearest`)
+  - `nearest`, `land`, `sea`.
+
+### Export formats
+
+- `format=csv` or `format=xlsx` to export.
+
+### Commercial usage
+
+- `apikey` is optional; docs describe it as required only for commercial use to access reserved resources.
+- Docs note the server URL requires the prefix `customer-` for commercial usage.
+
+## Hourly variables (docs list)
+
+Common pollutants and indices:
+
+- Particulate matter: `pm10`, `pm2_5`
+- Gases: `carbon_monoxide`, `nitrogen_dioxide`, `sulphur_dioxide`, `ozone`
+- AQI (European):
+  - `european_aqi` (consolidated max)
+  - `european_aqi_pm2_5`, `european_aqi_pm10`, `european_aqi_nitrogen_dioxide`, `european_aqi_ozone`, `european_aqi_sulphur_dioxide`
+- AQI (United States):
+  - `us_aqi` (consolidated max)
+  - `us_aqi_pm2_5`, `us_aqi_pm10`, `us_aqi_nitrogen_dioxide`, `us_aqi_ozone`, `us_aqi_sulphur_dioxide`, `us_aqi_carbon_monoxide`
+
+Pollen variables (Europe only, during pollen season with 4 days forecast):
+
+- `alder_pollen`, `birch_pollen`, `grass_pollen`, `mugwort_pollen`, `olive_pollen`, `ragweed_pollen`
+
+Other hourly variables called out in the docs UI include:
+
+- `carbon_dioxide`, `aerosol_optical_depth`, `dust`, `uv_index`, `uv_index_clear_sky`, `ammonia`, `methane`
+
+## European AQI scale (docs)
+
+- 0–20: good
+- 20–40: fair
+- 40–60: moderate
+- 60–80: poor
+- 80–100: very poor
+- >100: extremely poor
+
+Docs note: PM uses a 24-hour rolling average; gases use hourly values.
+
+### EU thresholds table (from docs)
+
+| Pollutant (μg/m³) | Timespan | Good | Fair | Moderate | Poor | Very poor | Extremely poor |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| PM2.5 | 24h | 0-10 | 10-20 | 20-25 | 25-50 | 50-75 | 75-800 |
+| PM10 | 24h | 0-20 | 20-40 | 40-50 | 50-100 | 100-150 | 150-1200 |
+| NO2 | 1h | 0-40 | 40-90 | 90-120 | 120-230 | 230-340 | 340-1000 |
+| O3 | 1h | 0-50 | 50-100 | 100-130 | 130-240 | 240-380 | 380-800 |
+| SO2 | 1h | 0-100 | 100-200 | 200-350 | 350-500 | 500-750 | 750-1250 |
+
+## US AQI scale (docs)
+
+- 0–50: good
+- 51–100: moderate
+- 101–150: unhealthy for sensitive groups
+- 151–200: unhealthy
+- 201–300: very unhealthy
+- 301–500: hazardous
+
+### US thresholds table (from docs)
+
+| Pollutant | Timespan | Good | Moderate | Unhealthy for Sensitive Groups | Unhealthy | Very Unhealthy | Hazardous | |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| O3 (ppb) | 8h | 0-55 | 55-70 | 70-85 | 85-105 | 105-200 | - | - |
+| O3 (ppb) | 1h | - | - | 125-165 | 165-205 | 205-405 | 405-505 | 505-605 |
+| PM2.5 (μg/m³) | 24h | 0-12 | 12-35.5 | 35.5-55.5 | 55.5-150.5 | 150.5-250.5 | 250.5-350.5 | 350.5-500.5 |
+| PM10 (μg/m³) | 24h | 0-55 | 55-155 | 155-255 | 255-355 | 355-425 | 425-505 | 505-605 |
+| CO (ppm) | 8h | 0-4.5 | 4.5-9.5 | 9.5-12.5 | 12.5-15.5 | 15.5-30.5 | 30.5-40.5 | 40.5-50.5 |
+| SO2 (ppb) | 1h | 0-35 | 35-75 | 75-185 | 185-305 | - | - | - |
+| SO2 (ppb) | 24h | - | - | - | - | 305-605 | 605-805 | 805-1005 |
+| NO2 (ppb) | 1h | 0-54 | 54-100 | 100-360 | 360-650 | 650-1250 | 1250-1650 | 1650-2050 |
+
+## Response structure (single-location)
+
+The docs show the canonical response shape:
+
+- `latitude`, `longitude`, `elevation`
+- `generationtime_ms`
+- `utc_offset_seconds`
+- `timezone`, `timezone_abbreviation`
+- `hourly` (object): `time[]` + arrays for each requested hourly variable
+- `hourly_units` (object): unit per hourly variable
+
+(If `current` was requested, a `current` object is included.)
+
+## Error handling
+
+The docs show JSON error objects returned with HTTP 400:
+
+```json
+{
+  "error": true,
+  "reason": "Cannot initialize WeatherVariable from invalid String value ..."
+}
+```
+
+## Attribution / acknowledgement (docs)
+
+Docs require users to provide attribution to:
+
+- CAMS ENSEMBLE data provider, and
+- Open-Meteo
+
+See the “Citation & Acknowledgement” section on the Air Quality docs page.

--- a/.agents/skills/open-meteo/references/climate-projection-api.md
+++ b/.agents/skills/open-meteo/references/climate-projection-api.md
@@ -1,0 +1,183 @@
+# Climate Projection API
+
+The Climate Projection API provides access to climate change projection data from 7 high-resolution CMIP6 models. It is designed for analyzing long-term climate trends from 1950 to 2050 with daily resolution.
+
+## Endpoint
+
+**Base URL:** `https://climate-api.open-meteo.com/v1/climate`
+
+## Required Parameters
+
+- **`latitude`** - Floating-point WGS84 coordinate (supports comma-separated values for multiple locations)
+- **`longitude`** - Floating-point WGS84 coordinate (supports comma-separated values for multiple locations)
+- **`start_date`** - ISO8601 format (yyyy-mm-dd). Available range: 1950-01-01 to 2050-12-31
+- **`end_date`** - ISO8601 format (yyyy-mm-dd). Available range: 1950-01-01 to 2050-12-31
+- **`models`** - Comma-separated list of climate models to query
+- **`daily`** - Comma-separated list of daily climate variables to retrieve
+
+## Optional Parameters
+
+| Parameter | Default | Options | Description |
+|-----------|---------|---------|-------------|
+| `temperature_unit` | celsius | celsius, fahrenheit | Temperature unit |
+| `wind_speed_unit` | kmh | kmh, ms, mph, kn | Wind speed unit |
+| `precipitation_unit` | mm | mm, inch | Precipitation unit |
+| `timeformat` | iso8601 | iso8601, unixtime | Time format |
+| `disable_bias_correction` | false | true, false | Disable statistical downscaling |
+| `cell_selection` | land | land, sea, nearest | Grid cell selection method |
+| `apikey` | - | - | Required for commercial use |
+
+## Available Climate Models (7 models)
+
+| Model Name | Origin | Institution | Resolution | Special Notes |
+|-----------|--------|-------------|------------|---------------|
+| **CMCC_CM2_VHR4** | Italy | Fondazione Centro Euro-Mediterraneo (CMCC) | 30 km | ⚠️ Lacks snowfall/solar/cloud data |
+| **FGOALS_f3_H** | China | Chinese Academy of Sciences (CAS) | 28 km | ⚠️ Limited humidity/wind aggregations |
+| **HiRAM_SIT_HR** | Taiwan | Academia Sinica (AS-RCEC) | 25 km | ⚠️ Limited humidity/wind aggregations |
+| **MRI_AGCM3_2_S** | Japan | Meteorological Research Institute (MRI) | 20 km | ✅ **Only model with full soil moisture coverage** |
+| **EC_Earth3P_HR** | Europe | EC-Earth Consortium/SMHI | 29 km | ✅ **Full soil moisture available** |
+| **MPI_ESM1_2_XR** | Germany | Max Planck Institute | 51 km | ⚠️ Limited humidity aggregations |
+| **NICAM16_8S** | Japan | MIROC/JAMSTEC | 31 km | ✅ Comprehensive variables except soil moisture |
+
+**Note:** Model names in API calls use underscores, not hyphens (e.g., `CMCC_CM2_VHR4`)
+
+## Daily Weather Variables
+
+### Temperature Variables
+- `temperature_2m_max` - Maximum daily air temperature at 2m (°C/°F)
+- `temperature_2m_min` - Minimum daily air temperature at 2m (°C/°F)
+- `temperature_2m_mean` - Mean daily air temperature at 2m (°C/°F)
+
+### Humidity Variables
+- `relative_humidity_2m_max` - Maximum relative humidity (%)
+- `relative_humidity_2m_min` - Minimum relative humidity (%)
+- `relative_humidity_2m_mean` - Mean relative humidity (%)
+
+**Note:** Some models only provide mean values for humidity.
+
+### Wind Variables
+- `wind_speed_10m_mean` - Mean daily wind speed at 10m (km/h, mph, m/s, kn)
+- `wind_speed_10m_max` - Maximum daily wind speed at 10m (km/h, mph, m/s, kn)
+
+### Precipitation Variables
+- `precipitation_sum` - Total daily precipitation (rain + snow) (mm/inch)
+- `rain_sum` - Liquid rain only (mm/inch)
+- `snowfall_sum` - Snowfall amount in snow water equivalent (cm)
+
+⚠️ **Snowfall Caveat:** May have larger biases in mountainous terrain as not adjusted for elevation differences.
+
+### Radiation & Cloud Variables
+- `shortwave_radiation_sum` - Daily sum of shortwave solar radiation (MJ/m²)
+- `cloud_cover_mean` - Mean daily cloud cover (%)
+
+### Soil Variables
+- `soil_moisture_0_to_10cm_mean` - Mean soil moisture in top 10cm layer (m³/m³)
+
+⚠️ **Limited Availability:** Only available for **MRI_AGCM3_2_S** and **EC_Earth3P_HR** models.
+
+### Atmospheric Pressure
+- `pressure_msl_mean` - Mean sea level pressure (hPa)
+
+### Dewpoint Variables
+- `mean_dewpoint_2m` - Mean dewpoint temperature (°C/°F)
+- `minimum_dewpoint_2m` - Minimum dewpoint temperature (°C/°F)
+- `maximum_dewpoint_2m` - Maximum dewpoint temperature (°C/°F)
+
+### Evapotranspiration
+- `reference_evapotranspiration_et0` - Reference evapotranspiration (mm/day)
+
+## Example API Calls
+
+### Single Location - Basic Temperature Request
+```
+https://climate-api.open-meteo.com/v1/climate?latitude=52.52&longitude=13.41&start_date=2040-01-01&end_date=2040-12-31&models=MRI_AGCM3_2_S&daily=temperature_2m_mean,temperature_2m_max,temperature_2m_min
+```
+
+### Multiple Models - Comprehensive Variables
+```
+https://climate-api.open-meteo.com/v1/climate?latitude=52.52&longitude=13.41&start_date=1950-01-01&end_date=2050-12-31&models=MRI_AGCM3_2_S,EC_Earth3P_HR&daily=temperature_2m_max,precipitation_sum,wind_speed_10m_mean&temperature_unit=celsius&wind_speed_unit=kmh
+```
+
+### Multiple Locations (Berlin & Paris)
+```
+https://climate-api.open-meteo.com/v1/climate?latitude=52.52,48.85&longitude=13.41,2.35&start_date=2020-01-01&end_date=2050-12-31&models=CMCC_CM2_VHR4&daily=temperature_2m_mean,precipitation_sum
+```
+
+### Soil Moisture Query (MRI Model)
+```
+https://climate-api.open-meteo.com/v1/climate?latitude=40.71&longitude=-74.01&start_date=2030-01-01&end_date=2030-12-31&models=MRI_AGCM3_2_S&daily=soil_moisture_0_to_10cm_mean,precipitation_sum
+```
+
+## Response Format
+
+```json
+{
+  "latitude": 52.52,
+  "longitude": 13.419,
+  "generationtime_ms": 2.2119,
+  "utc_offset_seconds": 0,
+  "timezone": "GMT",
+  "timezone_abbreviation": "GMT",
+  "elevation": 38.0,
+  "daily_units": {
+    "time": "iso8601",
+    "temperature_2m_max": "°C",
+    "temperature_2m_min": "°C"
+  },
+  "daily": {
+    "time": ["2040-01-01", "2040-01-02", ...],
+    "temperature_2m_max": [5.7, 6.7, ...],
+    "temperature_2m_min": [2.0, 4.2, ...]
+  }
+}
+```
+
+## Important Notes & Limitations
+
+### Data Quality & Purpose
+- **Past/Recent Data:** Serves model validation purposes, not actual historical measurements
+- **Future Projections:** Beyond 2050, projections highly dependent on emission scenarios (aligned with RCP8.5)
+
+### Bias Correction
+- **Default Behavior:** Linear bias correction applied monthly over 50-year time series
+- **Climate Signal:** Climate change signal is preserved during correction
+- **Disable Option:** Use `disable_bias_correction=true` to get raw model output
+
+### Variable-Specific Limitations
+- **Soil Moisture:** Only available in MRI_AGCM3_2_S and EC_Earth3P_HR models
+- **Snowfall:** May have larger biases in complex mountainous terrain
+- **Cloud Cover:** Regional/local scale uncertainties exist despite systematic bias correction
+- **Wind Speed:** Terrain complexity significantly impacts simulation accuracy
+
+### Elevation Adjustment
+- Temperature variables are elevation-adjusted using a 90-meter digital elevation model
+
+## Citation & Licensing
+
+Models use CMIP6 data licensed under CC BY 4.0. Users must cite:
+1. The CMIP6 program
+2. Open-Meteo attribution
+
+## Export Formats
+
+The API supports multiple export formats:
+- **JSON** (default)
+- **CSV**
+- **XLSX**
+
+## Use Cases
+
+- Long-term climate trend analysis (1950-2050)
+- Climate change impact assessment
+- Multi-model ensemble analysis
+- Regional climate projection comparisons
+- Agricultural planning and water resource management
+- Climate scenario modeling
+
+## Best Practices
+
+1. **Model Selection:** Use multiple models for ensemble analysis rather than relying on a single model
+2. **Variable Availability:** Check model capabilities before querying (e.g., soil moisture only in 2 models)
+3. **Time Range:** Request only needed date ranges to reduce response size
+4. **Bias Correction:** Keep default bias correction enabled unless you need raw model output
+5. **Validation:** For historical periods, compare against actual observations for validation purposes

--- a/.agents/skills/open-meteo/references/elevation-api.md
+++ b/.agents/skills/open-meteo/references/elevation-api.md
@@ -1,0 +1,32 @@
+# Elevation API
+
+The Elevation API provides the elevation in meters for a given set of coordinates based on a 90-meter digital elevation model.
+
+## Endpoint
+
+`https://api.open-meteo.com/v1/elevation`
+
+## Required Parameters
+
+-   `latitude`: A single floating-point number or a comma-separated list of WGS84 latitude coordinates.
+-   `longitude`: A single floating-point number or a comma-separated list of WGS84 longitude coordinates.
+
+Up to 100 coordinate pairs can be specified in a single request.
+
+## Response
+
+The API returns a JSON object with an `elevation` key. The value is an array of numbers, where each number is the elevation in meters for the corresponding coordinate pair in the request.
+
+```json
+{
+  "elevation": [165, 30]
+}
+```
+
+## Example
+
+Get the elevation for Mont Blanc and Berlin.
+
+```
+https://api.open-meteo.com/v1/elevation?latitude=45.83,52.52&longitude=6.86,13.41
+```

--- a/.agents/skills/open-meteo/references/ensemble-forecast-api.md
+++ b/.agents/skills/open-meteo/references/ensemble-forecast-api.md
@@ -1,0 +1,70 @@
+# Ensemble Forecast API
+
+The Ensemble Forecast API provides access to weather forecasts from multiple models or multiple runs of the same model. This approach helps to quantify forecast uncertainty.
+
+## Endpoint
+
+`https://ensemble-api.open-meteo.com/v1/ensemble`
+
+## Required Parameters
+
+-   `latitude`, `longitude`: Floating-point numbers for the WGS84 coordinates.
+-   `models`: A comma-separated list of ensemble weather models to query.
+
+## Optional Parameters
+
+-   `hourly` / `daily`: A comma-separated list of variables to retrieve. At least one is required.
+-   `forecast_days`: Number of forecast days. Default is 7, but can be up to 35 depending on the model.
+-   `past_days`: Number of past days to include. Default is 0.
+-   `timezone`: Timezone for returning timestamps. Defaults to `GMT`. It's recommended to use `timezone=auto`.
+-   `temperature_unit`: `celsius` (default) or `fahrenheit`.
+-   `wind_speed_unit`: `kmh` (default), `ms`, `mph`, `kn`.
+-   `precipitation_unit`: `mm` (default) or `inch`.
+
+## Hourly Variables
+
+A selection of available hourly variables. Note that the response will include values for each ensemble member (e.g., `temperature_2m_member_01`, `temperature_2m_member_02`, etc.).
+-   `temperature_2m`
+-   `relative_humidity_2m`
+-   `precipitation`
+-   `rain`
+-   `snowfall`
+-   `weather_code`
+-   `pressure_msl`
+-   `cloud_cover`
+-   `wind_speed_10m`
+-   `wind_direction_10m`
+-   `wind_gusts_10m`
+-   `cape`
+-   `snow_depth`
+
+## Daily Variables
+
+A selection of available daily aggregated variables:
+-   `temperature_2m_max`
+-   `temperature_2m_min`
+-   `temperature_2m_mean`
+-   `precipitation_sum`
+-   `rain_sum`
+-   `snowfall_sum`
+-   `wind_speed_10m_max`
+-   `wind_gusts_10m_max`
+
+## Available Models
+
+A selection of available ensemble models:
+-   `gfs_seamless`
+-   `icon_global`
+-   `icon_eu`
+-   `ecmwf_ifs025`
+-   `gfs013`
+-   `meteofrance_arome_france_hd`
+-   `meteofrance_arpege_europe`
+
+## Example
+
+Get the ensemble forecast for hourly temperature and precipitation for London for the next 2 days using the global ICON and GFS models.
+
+```
+https://ensemble-api.open-meteo.com/v1/ensemble?latitude=51.50&longitude=-0.12&hourly=temperature_2m,precipitation&models=icon_global,gfs013&forecast_days=2&timezone=auto
+```

--- a/.agents/skills/open-meteo/references/examples.md
+++ b/.agents/skills/open-meteo/references/examples.md
@@ -1,0 +1,114 @@
+# Examples (Geocoding → Forecast / Air Quality)
+
+All examples are derived from the official docs pages:
+
+- https://open-meteo.com/en/docs
+- https://open-meteo.com/en/docs/air-quality-api
+- https://open-meteo.com/en/docs/geocoding-api
+
+## Python (httpx) — geocode then forecast
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+def _raise_if_open_meteo_error(payload: dict[str, Any]) -> None:
+    if payload.get("error") is True:
+        reason = payload.get("reason")
+        raise RuntimeError(f"Open-Meteo error: {reason}")
+
+
+def geocode(name: str, *, language: str = "en", count: int = 1) -> dict[str, Any]:
+    url = "https://geocoding-api.open-meteo.com/v1/search"
+    params = {"name": name, "language": language, "count": count, "format": "json"}
+
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+    _raise_if_open_meteo_error(data)
+
+    results = data.get("results")
+    if not results:
+        raise ValueError(f"No geocoding results for: {name}")
+
+    return results[0]
+
+
+def forecast(latitude: float, longitude: float, timezone: str) -> dict[str, Any]:
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "hourly": "temperature_2m,precipitation,weather_code",
+        "daily": "temperature_2m_max,temperature_2m_min,precipitation_sum",
+        "current": "temperature_2m,wind_speed_10m",
+        "timezone": timezone,  # daily requires timezone per docs
+        "forecast_days": 2,
+    }
+
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+    _raise_if_open_meteo_error(data)
+    return data
+
+
+place = geocode("Berlin", language="en", count=1)
+lat = float(place["latitude"])
+lon = float(place["longitude"])
+tz = str(place.get("timezone") or "GMT")
+
+payload = forecast(lat, lon, tz)
+print(payload["timezone"], payload["hourly_units"].get("temperature_2m"))
+print(payload["hourly"]["time"][0], payload["hourly"]["temperature_2m"][0])
+```
+
+## Python (httpx) — air quality for the same point
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+def _raise_if_open_meteo_error(payload: dict[str, Any]) -> None:
+    if payload.get("error") is True:
+        raise RuntimeError(f"Open-Meteo error: {payload.get('reason')}")
+
+
+def air_quality(latitude: float, longitude: float, timezone: str) -> dict[str, Any]:
+    url = "https://air-quality-api.open-meteo.com/v1/air-quality"
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "hourly": "pm10,pm2_5,european_aqi,us_aqi",
+        "current": "pm10,pm2_5,european_aqi",
+        "timezone": timezone,
+        "forecast_days": 2,
+        "domains": "auto",
+    }
+
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+    _raise_if_open_meteo_error(data)
+    return data
+```
+
+## Notes
+
+- Variable names must match the docs exactly: e.g., `pm2_5` (not `pm2.5`).
+- If you set `timeformat=unixtime`, timestamps are in GMT+0; use `utc_offset_seconds` to derive local dates.
+- If you request `daily=...` on the Forecast API, you must set `timezone` (per docs).

--- a/.agents/skills/open-meteo/references/flood-forecast-api.md
+++ b/.agents/skills/open-meteo/references/flood-forecast-api.md
@@ -1,0 +1,40 @@
+# Flood Forecast API
+
+The Flood Forecast API provides river discharge forecasts from the Global Flood Awareness System (GloFAS). For a given coordinate, it returns data for the largest river within a 5 km radius.
+
+## Endpoint
+
+`https://flood-api.open-meteo.com/v1/flood`
+
+## Required Parameters
+
+-   `latitude`, `longitude`: Floating-point numbers for the WGS84 coordinates. Multiple locations can be specified as a comma-separated list.
+
+## Optional Parameters
+
+-   `daily`: A comma-separated list of daily flood variables to retrieve.
+-   `forecast_days`: Number of forecast days to retrieve. Default is 92, maximum is 210.
+-   `past_days`: Number of past days to include in the results. Default is 0.
+-   `start_date` / `end_date`: The specific time interval for the data, in `YYYY-MM-DD` format.
+-   `timeformat`: `iso8601` (default) or `unixtime`.
+-   `cell_selection`: How grid-cells are selected. `land` (default), `sea`, or `nearest`.
+
+## Daily Flood Variables
+
+A selection of available daily variables:
+-   `river_discharge`
+-   `river_discharge_mean`
+-   `river_discharge_median`
+-   `river_discharge_max`
+-   `river_discharge_min`
+-   `river_discharge_p25`
+-   `river_discharge_p75`
+-   `river_discharge_ensemble_member_01` (and other ensemble members)
+
+## Example
+
+Get the forecasted daily river discharge for the next 7 days for a location on the Danube river.
+
+```
+https://flood-api.open-meteo.com/v1/flood?latitude=48.208&longitude=16.373&daily=river_discharge&forecast_days=7
+```

--- a/.agents/skills/open-meteo/references/forecast-api.md
+++ b/.agents/skills/open-meteo/references/forecast-api.md
@@ -1,0 +1,136 @@
+# Open-Meteo Weather Forecast API (in-scope)
+
+Source of truth: https://open-meteo.com/en/docs
+
+## Base URL
+
+- `https://api.open-meteo.com/v1/forecast`
+
+## Request shape
+
+- HTTP method: `GET`
+- Query parameters are URL-encoded.
+
+### Multi-location batching
+
+- `latitude` and `longitude` accept **comma-separated lists**.
+- When multiple locations are requested, the **JSON output shape changes** (docs note this explicitly).
+- CSV/XLSX export adds a `location_id` column.
+
+## Core query parameters
+
+### Required
+
+- `latitude` (float)
+- `longitude` (float)
+
+### Variable selection
+
+- `hourly` (string array): comma-separated or repeated `&hourly=` parameters.
+- `daily` (string array): comma-separated or repeated `&daily=` parameters.
+  - **Important:** If `daily` variables are specified, `timezone` is required.
+- `current` (string array): current-condition variables.
+
+### Time controls
+
+- `timezone` (string, default `GMT`)
+  - Use a TZ database name (e.g., `Europe/Berlin`).
+  - `timezone=auto` resolves coordinates to the local timezone.
+  - If timezone is set, timestamps are returned in local time and data starts at 00:00 local-time.
+
+- `timeformat` (string, default `iso8601`)
+  - `iso8601` or `unixtime`.
+  - **If `unixtime`:** timestamps are returned in GMT+0; apply `utc_offset_seconds` to get correct local dates.
+
+- `forecast_days` (int 0–16, default 7)
+- `past_days` (int 0–92, default 0)
+
+- Fine-grained timestep control:
+  - `forecast_hours`, `past_hours`
+  - For 15-minutely data: `forecast_minutely_15`, `past_minutely_15`
+
+- Explicit time interval:
+  - `start_date`, `end_date` (YYYY-MM-DD)
+  - For hourly/15-minutely: `start_hour`, `end_hour`, `start_minutely_15`, `end_minutely_15` (YYYY-MM-DDThh:mm)
+
+### Units
+
+- `temperature_unit` (default `celsius`): set to `fahrenheit` to convert.
+- `wind_speed_unit` (default `kmh`): alternatives `ms`, `mph`, `kn`.
+- `precipitation_unit` (default `mm`): alternative `inch`.
+
+### Models
+
+- `models` (string array, default `auto`)
+  - Docs note: “Best match” provides the best forecast worldwide.
+  - “Seamless” combines models from a provider into a seamless prediction.
+
+### Elevation and grid-cell selection
+
+- `elevation` (float)
+  - Default: uses a 90m digital elevation model.
+  - `elevation=nan` disables downscaling.
+- `cell_selection` (string, default `land`)
+  - `land`: prefers a land grid-cell with similar elevation.
+  - `sea`: prefers sea grid-cells.
+  - `nearest`: nearest possible grid-cell.
+
+### Export formats
+
+- `format=csv` or `format=xlsx` to export.
+
+### Commercial usage
+
+- `apikey` is optional and described as required only for commercial use to access reserved resources.
+- Docs note the **server URL requires the prefix `customer-`** for commercial usage.
+
+## Variables (high-level map)
+
+The docs provide extensive variable lists. These are common, high-signal variables to start with:
+
+- Forecast `hourly`:
+  - `temperature_2m`, `relative_humidity_2m`, `apparent_temperature`
+  - `precipitation`, `rain`, `showers`, `snowfall`, `precipitation_probability`
+  - `wind_speed_10m`, `wind_direction_10m`, `wind_gusts_10m`
+  - `weather_code`, `cloud_cover`, `pressure_msl`, `visibility`
+
+- Forecast `daily`:
+  - `temperature_2m_max`, `temperature_2m_min`
+  - `precipitation_sum`, `rain_sum`, `snowfall_sum`
+  - `sunrise`, `sunset`, `daylight_duration`, `sunshine_duration`
+  - `wind_speed_10m_max`, `wind_gusts_10m_max`
+
+- Forecast `current`:
+  - any hourly variable can be requested as current; docs mention current values are based on 15-minutely data.
+
+## Response structure (single-location)
+
+The docs show the canonical response shape:
+
+- Top-level metadata:
+  - `latitude`, `longitude`, `elevation`
+  - `generationtime_ms`
+  - `utc_offset_seconds`
+  - `timezone`, `timezone_abbreviation`
+
+- Variable blocks:
+  - `current` (object): values for requested current variables + `time` and `interval` (seconds)
+  - `hourly` (object): `time[]` + arrays for each requested hourly variable
+  - `hourly_units` (object): unit per hourly variable
+  - `daily` / `daily_units` analogous
+
+## WMO weather codes
+
+- `weather_code` uses WMO interpretation codes.
+- See: `references/weather-codes.md`.
+
+## Error handling
+
+If URL parameters are invalid or variable names are misspelled, the API returns HTTP 400 with a JSON object:
+
+```json
+{
+  "error": true,
+  "reason": "Cannot initialize WeatherVariable from invalid String value ..."
+}
+```

--- a/.agents/skills/open-meteo/references/geocoding-api.md
+++ b/.agents/skills/open-meteo/references/geocoding-api.md
@@ -1,0 +1,74 @@
+# Open-Meteo Geocoding API (in-scope)
+
+Source of truth: https://open-meteo.com/en/docs/geocoding-api
+
+## Base URL
+
+- Search: `https://geocoding-api.open-meteo.com/v1/search`
+
+Docs also mention IDs can be resolved via:
+
+- Get by ID: `https://geocoding-api.open-meteo.com/v1/get?id=<id>`
+
+## Search parameters
+
+| Parameter | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `name` | yes |  | Search string: location name or postal code |
+| `count` | no | 10 | 1–100 allowed |
+| `language` | no | `en` | Lower-cased; returns translated results if available |
+| `format` | no | `json` | `json` or `protobuf` |
+| `countryCode` | no |  | ISO-3166-1 alpha2 filter |
+| `apikey` | no |  | Docs describe it as required only for commercial use (reserved resources) |
+
+### Matching behavior (docs)
+
+- empty string or 1 character → empty result
+- 2 characters → exact matching only
+- 3+ characters → fuzzy matching
+
+## Response
+
+On success, returns:
+
+```json
+{
+  "results": [
+    {
+      "id": 2950159,
+      "name": "Berlin",
+      "latitude": 52.52437,
+      "longitude": 13.41053,
+      "elevation": 74.0,
+      "feature_code": "PPLC",
+      "country_code": "DE",
+      "timezone": "Europe/Berlin",
+      "population": 3426354,
+      "postcodes": ["10967", "13347"],
+      "country": "Deutschland",
+      "admin1": "Berlin"
+    }
+  ]
+}
+```
+
+Docs note:
+
+- Empty fields are not returned (e.g., `admin4` may be missing).
+- The schema includes administrative levels (`admin1..admin4`) and corresponding IDs.
+
+## Error handling
+
+Docs show HTTP 400 with a JSON error object, e.g.:
+
+```json
+{
+  "error": true,
+  "reason": "Parameter count must be between 1 and 100."
+}
+```
+
+## Attribution (docs)
+
+- Location data based on GeoNames
+- Country flags from HatScripts/circle-flags

--- a/.agents/skills/open-meteo/references/historical-weather-api.md
+++ b/.agents/skills/open-meteo/references/historical-weather-api.md
@@ -1,0 +1,72 @@
+# Historical Weather API
+
+The Historical Weather API provides weather data from the past, based on reanalysis models like ERA5. It is ideal for accessing consistent, long-term weather records.
+
+## Endpoint
+
+`https://archive-api.open-meteo.com/v1/archive`
+
+## Required Parameters
+
+-   `latitude`, `longitude`: Floating-point numbers for the WGS84 coordinates. Multiple locations can be specified as a comma-separated list.
+-   `start_date`: The start date for the time interval, in `YYYY-MM-DD` format.
+-   `end_date`: The end date for the time interval, in `YYYY-MM-DD` format.
+-   `hourly` or `daily`: You must specify at least one of these with a comma-separated list of weather variables.
+
+## Optional Parameters
+
+-   `temperature_unit`: `celsius` (default) or `fahrenheit`.
+-   `wind_speed_unit`: `kmh` (default), `ms`, `mph`, `kn`.
+-   `precipitation_unit`: `mm` (default) or `inch`.
+-   `timezone`: Timezone for returning timestamps (e.g., `America/New_York`). Defaults to `GMT` if not specified. It is recommended to use `timezone=auto` to get the local timezone.
+-   `models`: Allows specifying reanalysis models. `ERA5` is often used for a globally complete dataset from 1940 onwards.
+
+## Hourly Weather Variables
+
+A selection of available hourly variables:
+-   `temperature_2m`
+-   `relative_humidity_2m`
+-   `dew_point_2m`
+-   `apparent_temperature`
+-   `precipitation`
+-   `rain`
+-   `snowfall`
+-   `snow_depth`
+-   `weather_code`
+-   `pressure_msl`
+-   `surface_pressure`
+-   `cloud_cover`
+-   `wind_speed_10m`
+-   `wind_direction_10m`
+-   `soil_temperature_0_to_7cm`
+-   `soil_moisture_0_to_7cm`
+
+## Daily Weather Variables
+
+A selection of available daily aggregated variables:
+-   `weather_code_mean`
+-   `temperature_2m_max`
+-   `temperature_2m_min`
+-   `temperature_2m_mean`
+-   `apparent_temperature_max`
+-   `apparent_temperature_min`
+-   `apparent_temperature_mean`
+-   `sunrise`
+-   `sunset`
+-   `precipitation_sum`
+-   `rain_sum`
+-   `snowfall_sum`
+-   `precipitation_hours`
+-   `wind_speed_10m_max`
+-   `wind_gusts_10m_max`
+-   `wind_direction_10m_dominant`
+-   `shortwave_radiation_sum`
+-   `et0_fao_evapotranspiration`
+
+## Example
+
+Get daily maximum temperature and precipitation sum for Berlin from January 1st to 7th, 2023.
+
+```
+https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2023-01-01&end_date=2023-01-07&daily=temperature_2m_max,precipitation_sum&timezone=Europe/Berlin
+```

--- a/.agents/skills/open-meteo/references/marine-weather-api.md
+++ b/.agents/skills/open-meteo/references/marine-weather-api.md
@@ -1,0 +1,57 @@
+# Marine Weather API
+
+The Marine Weather API provides detailed ocean and wave forecasts, essential for marine activities.
+
+## Endpoint
+
+`https://marine-api.open-meteo.com/v1/marine`
+
+## Required Parameters
+
+-   `latitude`, `longitude`: Floating-point numbers for the WGS84 coordinates. Multiple locations can be specified as a comma-separated list.
+
+## Optional Parameters
+
+-   `hourly`: A comma-separated list of marine weather variables to retrieve for each hour.
+-   `daily`: A comma-separated list of daily aggregated marine variables. If used, `timezone` is required.
+-   `current`: A comma-separated list of variables for the current marine conditions.
+-   `timezone`: Timezone for returning timestamps (e.g., `America/New_York`). Defaults to `GMT`. It's recommended to use `timezone=auto` for the local timezone.
+-   `forecast_days`: Number of days for the forecast, from 1 to 16. Default is 7.
+-   `timeformat`: `iso8601` (default) or `unixtime`.
+
+## Hourly Marine Variables
+
+A selection of available hourly variables:
+-   `wave_height`
+-   `wave_direction`
+-   `wave_period`
+-   `wind_wave_height`
+-   `wind_wave_direction`
+-   `wind_wave_period`
+-   `swell_wave_height`
+-   `swell_wave_direction`
+-   `swell_wave_period`
+-   `sea_surface_temperature`
+-   `ocean_current_velocity`
+-   `ocean_current_direction`
+
+## Daily Marine Variables
+
+A selection of available daily aggregated variables:
+-   `wave_height_max`
+-   `wave_direction_dominant`
+-   `wave_period_max`
+-   `wind_wave_height_max`
+-   `wind_wave_direction_dominant`
+-   `wind_wave_period_max`
+-   `swell_wave_height_max`
+-   `swell_wave_direction_dominant`
+-   `swell_wave_period_max`
+
+## Example
+
+Get daily max wave height for a location in the North Atlantic for the next 5 days.
+
+```
+https://marine-api.open-meteo.com/v1/marine?latitude=54.5&longitude=-15.5&daily=wave_height_max&forecast_days=5&timezone=auto
+```

--- a/.agents/skills/open-meteo/references/models.md
+++ b/.agents/skills/open-meteo/references/models.md
@@ -1,0 +1,94 @@
+# Forecast `models=` selection guide
+
+Source: Official Open-Meteo provider documentation pages.
+
+**Scope:** Weather Forecast API only. Does not cover Historical, Ensemble, Seasonal, Climate, Marine, Satellite Radiation, Elevation, or Flood APIs.
+
+## How model selection works
+
+- `models=auto` (default) — "Best match" combines optimal models automatically
+- Explicit `models=<key>` — select specific provider/model
+- Provider-specific endpoints — some providers have dedicated endpoints (e.g., `/v1/ecmwf`)
+
+## Endpoints vs `models=`
+
+**Generic Forecast endpoint (recommended):**
+- URL: `https://api.open-meteo.com/v1/forecast`
+- Use `models=auto` or `models=<provider_key>`
+- Most flexible, supports switching providers per request
+
+**Provider-specific endpoints:**
+- `/v1/dwd-icon` — DWD ICON
+- `/v1/gfs` — NOAA GFS/HRRR
+- `/v1/ecmwf` — ECMWF IFS/AIFS
+- `/v1/bom` — Australia BOM
+- `/v1/cma` — China CMA
+
+Start with the generic endpoint + `models=auto` unless you have specific requirements.
+
+## Model selection rules
+
+1. **Default to `models=auto`** — works globally, picks best available
+
+2. **Use "seamless" models** when you want:
+   - High-resolution short-range (2–3 days) + automatic extension with global models
+
+3. **Use regional models** when you need:
+   - Higher spatial resolution
+   - Only care about short horizons (nowcast / 0–72h)
+
+4. **Variable availability varies:**
+   - Not all providers have direct solar radiation (some derive it)
+   - Cloud cover at 2m (fog indicator) — only KMA, UKMO UKV, DMI
+   - Probability data — only NBM (NOAA), ARPEGE (Météo-France)
+
+5. **Licensing:**
+   - UKMO: CC BY-SA 4.0 (derived products must stay compatible)
+
+6. **Operational notes:**
+   - BOM: temporary suspension due to platform upgrades
+   - CMA: recent overload/reliability issues
+
+## Provider quick reference
+
+| Provider | Region | Resolution | Horizon | Seamless key |
+|----------|--------|------------|---------|--------------|
+| DWD ICON | Germany/Europe | 2–11 km | 2–7.5d | `icon_seamless` |
+| NOAA GFS | Global/US | 3–13 km | 16d | `gfs_seamless` |
+| Météo-France | France/Europe | 1.5–25 km | 2–4d | `meteofrance_seamless` |
+| ECMWF | Global | 9–25 km | 15d | `ecmwf_ifs` |
+| UKMO | UK/Global | 2–10 km | 2–7d | `ukmo_seamless` |
+| KMA | Korea/Global | 1.5–12 km | 2–12d | `kma_seamless` |
+| JMA | Japan/Global | 5–55 km | 4–11d | `jma_seamless` |
+| MeteoSwiss | Central Europe | 1–2 km | 33h–5d | `meteoswiss_icon_ch1` |
+| MET Norway | Nordic | 1 km | 2.5d | `metno_seamless` |
+| GEM | Canada/Global | 2.5–15 km | 2–10d | `gem_seamless` |
+| BOM | Australia | 15 km | 10d | `bom_access_global` |
+| CMA | China/Global | 15 km | 10d | `cma_grapes_global` |
+| KNMI | Netherlands | 2–5.5 km | 2.5–10d | `knmi_seamless` |
+| DMI | Denmark | 2 km | 2.5–10d | `dmi_seamless` |
+| ItaliaMeteo | Southern Europe | 2 km | 3d | `italia_meteo_arpae_icon_2i` |
+
+## Finding specific model keys
+
+If you need a specific sub-model (not seamless):
+1. Go to the provider's docs page
+2. Use "Preview → URL" generator
+3. Copy `models=...` values from the generated URL
+
+Provider docs:
+- https://open-meteo.com/en/docs/dwd-api
+- https://open-meteo.com/en/docs/gfs-api
+- https://open-meteo.com/en/docs/ecmwf-api
+- https://open-meteo.com/en/docs/meteofrance-api
+- https://open-meteo.com/en/docs/ukmo-api
+- https://open-meteo.com/en/docs/kma-api
+- https://open-meteo.com/en/docs/jma-api
+- https://open-meteo.com/en/docs/meteoswiss-api
+- https://open-meteo.com/en/docs/metno-api
+- https://open-meteo.com/en/docs/gem-api
+- https://open-meteo.com/en/docs/bom-api
+- https://open-meteo.com/en/docs/cma-api
+- https://open-meteo.com/en/docs/knmi-api
+- https://open-meteo.com/en/docs/dmi-api
+- https://open-meteo.com/en/docs/italia-meteo-arpae-api

--- a/.agents/skills/open-meteo/references/seasonal-forecast-api.md
+++ b/.agents/skills/open-meteo/references/seasonal-forecast-api.md
@@ -1,0 +1,57 @@
+# Seasonal Forecast API
+
+The Seasonal Forecast API provides long-range forecasts up to 7 months ahead, based on models like the ECMWF SEAS5. It is useful for understanding temperature and precipitation anomalies over a longer period.
+
+## Endpoint
+
+`https://seasonal-api.open-meteo.com/v1/seasonal`
+
+## Required Parameters
+
+-   `latitude`, `longitude`: Floating-point numbers for the WGS84 coordinates.
+
+## Optional Parameters
+
+-   `hourly` / `daily`: A comma-separated list of variables to retrieve. At least one is required. Note: The "hourly" data is typically aggregated at a 6-hourly interval for seasonal forecasts.
+-   `forecast_days`: Number of forecast days. Default is for 6 months.
+-   `past_days`: Number of past days to include.
+-   `start_date` / `end_date`: The specific time interval for the data, in `YYYY-MM-DD` format.
+-   `timezone`: Timezone for returning timestamps. Defaults to `GMT`. It's recommended to use `timezone=auto`.
+-   `temperature_unit`: `celsius` (default) or `fahrenheit`.
+-   `wind_speed_unit`: `kmh` (default), `ms`, `mph`, `kn`.
+-   `precipitation_unit`: `mm` (default) or `inch`.
+
+## 6-Hourly Variables
+
+A selection of available 6-hourly variables:
+-   `temperature_2m`
+-   `relative_humidity_2m`
+-   `dew_point_2m`
+-   `apparent_temperature`
+-   `pressure_msl`
+-   `total_cloud_cover`
+-   `precipitation`
+-   `rain`
+-   `snowfall`
+-   `weather_code`
+-   `wind_speed_10m`
+-   `wind_direction_10m`
+-   `soil_temperature_0_to_7cm`
+
+## Daily Variables
+
+A selection of available daily aggregated variables:
+-   `temperature_2m_max`
+-   `temperature_2m_min`
+-   `temperature_2m_mean`
+-   `precipitation_sum`
+-   `rain_sum`
+-   `snowfall_sum`
+
+## Example
+
+Get the mean daily temperature forecast for the next 3 months for Paris.
+
+```
+https://seasonal-api.open-meteo.com/v1/seasonal?latitude=48.85&longitude=2.35&daily=temperature_2m_mean&forecast_days=92&timezone=auto
+```

--- a/.agents/skills/open-meteo/references/weather-codes.md
+++ b/.agents/skills/open-meteo/references/weather-codes.md
@@ -1,0 +1,23 @@
+# WMO Weather interpretation codes (WW)
+
+Source of truth: https://open-meteo.com/en/docs
+
+Open-Meteo’s `weather_code` uses WMO interpretation codes.
+
+| Code | Description |
+| --- | --- |
+| 0 | Clear sky |
+| 1, 2, 3 | Mainly clear, partly cloudy, and overcast |
+| 45, 48 | Fog and depositing rime fog |
+| 51, 53, 55 | Drizzle: Light, moderate, and dense intensity |
+| 56, 57 | Freezing Drizzle: Light and dense intensity |
+| 61, 63, 65 | Rain: Slight, moderate and heavy intensity |
+| 66, 67 | Freezing Rain: Light and heavy intensity |
+| 71, 73, 75 | Snow fall: Slight, moderate, and heavy intensity |
+| 77 | Snow grains |
+| 80, 81, 82 | Rain showers: Slight, moderate, and violent |
+| 85, 86 | Snow showers slight and heavy |
+| 95* | Thunderstorm: Slight or moderate |
+| 96, 99* | Thunderstorm with slight and heavy hail |
+
+\* Thunderstorm forecast with hail is only available in Central Europe (per docs).

--- a/.claude/skills/open-meteo
+++ b/.claude/skills/open-meteo
@@ -1,0 +1,1 @@
+../../.agents/skills/open-meteo

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ OPEN_METEO_SEASONAL_API_URL=https://seasonal-api.open-meteo.com
 OPEN_METEO_ENSEMBLE_API_URL=https://ensemble-api.open-meteo.com
 OPEN_METEO_GEOCODING_API_URL=https://geocoding-api.open-meteo.com
 OPEN_METEO_FLOOD_API_URL=https://flood-api.open-meteo.com
+OPEN_METEO_CLIMATE_API_URL=https://climate-api.open-meteo.com

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "open-meteo": {
+      "command": "npx",
+      "args": ["-y", "open-meteo-mcp-server"],
+      "env": {
+        "OPEN_METEO_API_URL": "https://api.open-meteo.com",
+        "OPEN_METEO_AIR_QUALITY_API_URL": "https://air-quality-api.open-meteo.com",
+        "OPEN_METEO_MARINE_API_URL": "https://marine-api.open-meteo.com",
+        "OPEN_METEO_ARCHIVE_API_URL": "https://archive-api.open-meteo.com",
+        "OPEN_METEO_SEASONAL_API_URL": "https://seasonal-api.open-meteo.com",
+        "OPEN_METEO_ENSEMBLE_API_URL": "https://ensemble-api.open-meteo.com",
+        "OPEN_METEO_GEOCODING_API_URL": "https://geocoding-api.open-meteo.com",
+        "OPEN_METEO_FLOOD_API_URL": "https://flood-api.open-meteo.com"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,7 @@ jspm_packages/
 .vscode-test
 
 # Claude/MCP specific
-.claude/
-.agents/
+.claude/settings.local.json
 .cursor/
 .mcp.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ The server uses environment variables for API endpoints with fallback defaults:
 - `OPEN_METEO_ENSEMBLE_API_URL` - Ensemble forecasts
 - `OPEN_METEO_GEOCODING_API_URL` - Geocoding service
 - `OPEN_METEO_FLOOD_API_URL` - Flood forecast service
+- `OPEN_METEO_CLIMATE_API_URL` - Climate projection service
 
 Transport configuration:
 - `TRANSPORT` - Set to `http` to enable Streamable HTTP mode (default: stdio)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Add the following configuration to your Claude Desktop config file:
         "OPEN_METEO_SEASONAL_API_URL": "https://seasonal-api.open-meteo.com",
         "OPEN_METEO_ENSEMBLE_API_URL": "https://ensemble-api.open-meteo.com",
         "OPEN_METEO_GEOCODING_API_URL": "https://geocoding-api.open-meteo.com",
-        "OPEN_METEO_FLOOD_API_URL": "https://flood-api.open-meteo.com"
+        "OPEN_METEO_FLOOD_API_URL": "https://flood-api.open-meteo.com",
+        "OPEN_METEO_CLIMATE_API_URL": "https://climate-api.open-meteo.com"
       }
     }
   }
@@ -123,7 +124,8 @@ If you're developing locally or installed from source:
         "OPEN_METEO_SEASONAL_API_URL": "https://seasonal-api.open-meteo.com",
         "OPEN_METEO_ENSEMBLE_API_URL": "https://ensemble-api.open-meteo.com",
         "OPEN_METEO_GEOCODING_API_URL": "https://geocoding-api.open-meteo.com",
-        "OPEN_METEO_FLOOD_API_URL": "https://flood-api.open-meteo.com"
+        "OPEN_METEO_FLOOD_API_URL": "https://flood-api.open-meteo.com",
+        "OPEN_METEO_CLIMATE_API_URL": "https://climate-api.open-meteo.com"
       }
     }
   }
@@ -278,6 +280,7 @@ All environment variables are optional and have sensible defaults:
 - `OPEN_METEO_ENSEMBLE_API_URL` - Ensemble forecast API URL (default: https://ensemble-api.open-meteo.com)
 - `OPEN_METEO_GEOCODING_API_URL` - Geocoding API URL (default: https://geocoding-api.open-meteo.com)
 - `OPEN_METEO_FLOOD_API_URL` - Flood forecast API URL (default: https://flood-api.open-meteo.com)
+- `OPEN_METEO_CLIMATE_API_URL` - Climate projection API URL (default: https://climate-api.open-meteo.com)
 - `TRANSPORT` - Transport mode: `http` for Streamable HTTP, omit for stdio (default: stdio)
 - `PORT` - HTTP server port when using HTTP transport (default: 3000)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
       # - OPEN_METEO_ENSEMBLE_API_URL=https://ensemble-api.open-meteo.com
       # - OPEN_METEO_GEOCODING_API_URL=https://geocoding-api.open-meteo.com
       # - OPEN_METEO_FLOOD_API_URL=https://flood-api.open-meteo.com
+      # - OPEN_METEO_CLIMATE_API_URL=https://climate-api.open-meteo.com
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       # - OPEN_METEO_ENSEMBLE_API_URL=https://ensemble-api.open-meteo.com
       # - OPEN_METEO_GEOCODING_API_URL=https://geocoding-api.open-meteo.com
       # - OPEN_METEO_FLOOD_API_URL=https://flood-api.open-meteo.com
+      # - OPEN_METEO_CLIMATE_API_URL=https://climate-api.open-meteo.com
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ export class OpenMeteoClient {
   private ensembleClient: AxiosInstance;
   private geocodingClient: AxiosInstance;
   private floodClient: AxiosInstance;
+  private climateClient: AxiosInstance;
 
   constructor(baseURL: string = process.env.OPEN_METEO_API_URL || 'https://api.open-meteo.com') {
     const config = {
@@ -42,6 +43,7 @@ export class OpenMeteoClient {
     const ensembleURL = process.env.OPEN_METEO_ENSEMBLE_API_URL || 'https://ensemble-api.open-meteo.com';
     const geocodingURL = process.env.OPEN_METEO_GEOCODING_API_URL || 'https://geocoding-api.open-meteo.com';
     const floodURL = process.env.OPEN_METEO_FLOOD_API_URL || 'https://flood-api.open-meteo.com';
+    const climateURL = process.env.OPEN_METEO_CLIMATE_API_URL || 'https://climate-api.open-meteo.com';
 
     this.client = axios.create({ baseURL, ...config });
     this.airQualityClient = axios.create({ baseURL: airQualityURL, ...config });
@@ -51,6 +53,7 @@ export class OpenMeteoClient {
     this.ensembleClient = axios.create({ baseURL: ensembleURL, ...config });
     this.geocodingClient = axios.create({ baseURL: geocodingURL, ...config });
     this.floodClient = axios.create({ baseURL: floodURL, ...config });
+    this.climateClient = axios.create({ baseURL: climateURL, ...config });
   }
 
   private buildParams(params: Record<string, unknown>): Record<string, string> {
@@ -175,7 +178,7 @@ export class OpenMeteoClient {
   }
 
   async getClimate(params: ClimateParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/climate', {
+    const response = await this.climateClient.get('/v1/climate', {
       params: this.buildParams(params)
     });
     return response.data;


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the Climate Projection API implementation and updates the documentation with accurate information from the official Open-Meteo API.

## Changes Made

### 🐛 Bug Fixes
- **Fixed incorrect API endpoint**: Climate API was using `api.open-meteo.com` instead of `climate-api.open-meteo.com`, causing all requests to return 404 errors
- Added dedicated `climateClient` instance following the same pattern as other specialized APIs (marine, seasonal, ensemble)
- Modified `getClimate()` method to use the correct client

### 📝 Documentation Updates
- Removed incorrect "Not Found" warning from `climate-projection-api.md`
- Added comprehensive documentation with information from official API:
  - All 7 CMIP6 models with detailed characteristics and limitations
  - Complete list of daily weather variables with descriptions
  - Model-specific capabilities (e.g., soil moisture only available in 2 models)
  - Optional parameters (units, bias correction, cell selection)
  - Working example URLs for various use cases
  - Important notes on data quality, limitations, and best practices
- Updated `README.md` to include `OPEN_METEO_CLIMATE_API_URL` in all configuration examples
- Updated `CLAUDE.md` to document new `OPEN_METEO_CLIMATE_API_URL` environment variable

### ⚙️ Configuration
- Added support for `OPEN_METEO_CLIMATE_API_URL` environment variable (defaults to `https://climate-api.open-meteo.com`)

## Testing

Verified the fix works correctly:
```bash
curl "https://climate-api.open-meteo.com/v1/climate?latitude=48.85&longitude=2.35&start_date=2040-06-01&end_date=2040-06-07&models=MRI_AGCM3_2_S,EC_Earth3P_HR&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,soil_moisture_0_to_10cm_mean"
```

✅ Returns valid climate projection data
✅ Multi-model support working
✅ Soil moisture data available for compatible models
✅ Code compiles without errors

## Impact

- Climate Projection tool (`climate_projection`) now functional
- Users can access CMIP6 climate model data from 1950-2050
- Consistent architecture with other specialized API clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)