### PR TITLE
Fix npx configuration for cross-platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add the following configuration to your Claude Desktop config file:
   "mcpServers": {
     "open-meteo": {
       "command": "npx",
-      "args": ["open-meteo-mcp-server"]
+      "args": ["-y", "-p", "open-meteo-mcp-server", "open-meteo-mcp-server"]
     }
   }
 }
@@ -89,7 +89,7 @@ Add the following configuration to your Claude Desktop config file:
   "mcpServers": {
     "open-meteo": {
       "command": "npx",
-      "args": ["open-meteo-mcp-server"],
+      "args": ["-y", "-p", "open-meteo-mcp-server", "open-meteo-mcp-server"],
       "env": {
         "OPEN_METEO_API_URL": "https://api.open-meteo.com",
         "OPEN_METEO_AIR_QUALITY_API_URL": "https://air-quality-api.open-meteo.com",
@@ -141,7 +141,7 @@ If you're using your own Open-Meteo instance:
   "mcpServers": {
     "open-meteo": {
       "command": "npx",
-      "args": ["open-meteo-mcp-server"],
+      "args": ["-y", "-p", "open-meteo-mcp-server", "open-meteo-mcp-server"],
       "env": {
         "OPEN_METEO_API_URL": "https://your-meteo-api.example.com",
         "OPEN_METEO_AIR_QUALITY_API_URL": "https://air-quality-api.example.com",


### PR DESCRIPTION
## Summary

Fixes the npx configuration to work reliably across all operating systems (Windows, macOS, Linux).

## Problem

The current configuration `npx open-meteo-mcp-server` fails on some systems with the error:
```
sh: open-meteo-mcp-server: command not found
```

## Solution

Update all npx configurations to use the explicit package flag:
```json
"args": ["-y", "-p", "open-meteo-mcp-server", "open-meteo-mcp-server"]
```

This syntax explicitly tells npx:
1. `-y` - Auto-accept installation
2. `-p open-meteo-mcp-server` - Install this package
3. `open-meteo-mcp-server` - Execute this command from the package

## Changes

- ✅ Updated simple configuration example
- ✅ Updated full configuration with environment variables  
- ✅ Updated custom instance configuration

## Testing

- [x] Tested on macOS - works correctly
- [x] Verified package loads in Claude Desktop without errors

## Impact

This change ensures all users can successfully configure the MCP server regardless of their operating system, improving the first-time setup experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)