### PR TITLE
Add missing air quality variables (pollen, AQI, UV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This MCP server provides complete access to Open-Meteo APIs, including:
 ### Core Weather APIs
 - **Weather Forecast** (`weather_forecast`) - 7-day forecasts with hourly and daily resolution
 - **Weather Archive** (`weather_archive`) - Historical ERA5 data from 1940 to present
-- **Air Quality** (`air_quality`) - PM2.5, PM10, ozone, nitrogen dioxide and other pollutants
+- **Air Quality** (`air_quality`) - PM2.5, PM10, ozone, nitrogen dioxide, pollen, European/US AQI indices, UV index and other pollutants
 - **Marine Weather** (`marine_weather`) - Wave height, wave period, wave direction and sea surface temperature
 - **Elevation** (`elevation`) - Digital elevation model data for given coordinates
 - **Geocoding** (`geocoding`) - Search locations worldwide by name or postal code, get coordinates and detailed location information
@@ -373,6 +373,27 @@ Show me temperature projections for New York from 2050 to 2070 using CMIP6 model
 - `sulphur_dioxide` : Sulfur dioxide
 - `ammonia` : Ammonia
 - `dust` : Dust particles
+- `alder_pollen` : Alder pollen (Europe only)
+- `birch_pollen` : Birch pollen (Europe only)
+- `grass_pollen` : Grass pollen (Europe only)
+- `mugwort_pollen` : Mugwort pollen (Europe only)
+- `olive_pollen` : Olive pollen (Europe only)
+- `ragweed_pollen` : Ragweed pollen (Europe only)
+- `european_aqi` : European Air Quality Index
+- `european_aqi_pm2_5` : European AQI for PM2.5
+- `european_aqi_pm10` : European AQI for PM10
+- `european_aqi_nitrogen_dioxide` : European AQI for NO₂
+- `european_aqi_ozone` : European AQI for ozone
+- `european_aqi_sulphur_dioxide` : European AQI for SO₂
+- `us_aqi` : US Air Quality Index
+- `us_aqi_pm2_5` : US AQI for PM2.5
+- `us_aqi_pm10` : US AQI for PM10
+- `us_aqi_nitrogen_dioxide` : US AQI for NO₂
+- `us_aqi_ozone` : US AQI for ozone
+- `us_aqi_sulphur_dioxide` : US AQI for SO₂
+- `us_aqi_carbon_monoxide` : US AQI for CO
+- `uv_index` : UV index
+- `uv_index_clear_sky` : UV index under clear sky conditions
 
 ### Marine Weather Variables
 - `wave_height` : Wave height

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -152,7 +152,7 @@ export const WEATHER_ARCHIVE_TOOL: Tool = {
 
 export const AIR_QUALITY_TOOL: Tool = {
   name: 'air_quality',
-  description: 'Get air quality forecast data including PM2.5, PM10, ozone, nitrogen dioxide and other pollutants.',
+  description: 'Get air quality forecast data including PM2.5, PM10, ozone, nitrogen dioxide, pollen, European/US AQI indices, UV index and other pollutants.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -175,7 +175,11 @@ export const AIR_QUALITY_TOOL: Tool = {
           enum: [
             'pm10', 'pm2_5', 'carbon_monoxide', 'nitrogen_dioxide', 'ozone',
             'sulphur_dioxide', 'ammonia', 'dust', 'aerosol_optical_depth',
-            'carbon_dioxide', 'methane'
+            'carbon_dioxide', 'methane',
+            'alder_pollen', 'birch_pollen', 'grass_pollen', 'mugwort_pollen', 'olive_pollen', 'ragweed_pollen',
+            'european_aqi', 'european_aqi_pm2_5', 'european_aqi_pm10', 'european_aqi_nitrogen_dioxide', 'european_aqi_ozone', 'european_aqi_sulphur_dioxide',
+            'us_aqi', 'us_aqi_pm2_5', 'us_aqi_pm10', 'us_aqi_nitrogen_dioxide', 'us_aqi_ozone', 'us_aqi_sulphur_dioxide', 'us_aqi_carbon_monoxide',
+            'uv_index', 'uv_index_clear_sky'
           ]
         },
         description: 'Air quality variables to retrieve'

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,11 @@ export const ArchiveParamsSchema = CoordinateSchema.extend({
 export const AirQualityVariablesSchema = z.array(z.enum([
   'pm10', 'pm2_5', 'carbon_monoxide', 'nitrogen_dioxide', 'ozone',
   'sulphur_dioxide', 'ammonia', 'dust', 'aerosol_optical_depth',
-  'carbon_dioxide', 'methane'
+  'carbon_dioxide', 'methane',
+  'alder_pollen', 'birch_pollen', 'grass_pollen', 'mugwort_pollen', 'olive_pollen', 'ragweed_pollen',
+  'european_aqi', 'european_aqi_pm2_5', 'european_aqi_pm10', 'european_aqi_nitrogen_dioxide', 'european_aqi_ozone', 'european_aqi_sulphur_dioxide',
+  'us_aqi', 'us_aqi_pm2_5', 'us_aqi_pm10', 'us_aqi_nitrogen_dioxide', 'us_aqi_ozone', 'us_aqi_sulphur_dioxide', 'us_aqi_carbon_monoxide',
+  'uv_index', 'uv_index_clear_sky'
 ])).optional();
 
 export const AirQualityParamsSchema = CoordinateSchema.extend({


### PR DESCRIPTION
## Summary
- Add 21 missing variables to the `air_quality` tool to align with the Open-Meteo Air Quality API
- **Pollen (6)**: `alder_pollen`, `birch_pollen`, `grass_pollen`, `mugwort_pollen`, `olive_pollen`, `ragweed_pollen` (Europe only)
- **European AQI (6)**: `european_aqi`, `european_aqi_pm2_5`, `european_aqi_pm10`, `european_aqi_nitrogen_dioxide`, `european_aqi_ozone`, `european_aqi_sulphur_dioxide`
- **US AQI (7)**: `us_aqi`, `us_aqi_pm2_5`, `us_aqi_pm10`, `us_aqi_nitrogen_dioxide`, `us_aqi_ozone`, `us_aqi_sulphur_dioxide`, `us_aqi_carbon_monoxide`
- **UV (2)**: `uv_index`, `uv_index_clear_sky`

## Files changed
- `src/types.ts` — Updated `AirQualityVariablesSchema` Zod enum
- `src/tools.ts` — Updated `AIR_QUALITY_TOOL` JSON schema enum and description
- `README.md` — Updated documentation with all new variables

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run build` — pass
- [x] Functional test: all 21 new variables return valid data from the Open-Meteo API (tested on Paris coordinates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)