### PR TITLE
fix: align Zod validation with corrected models constraints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import type {
   AirQualityParams,
   ArchiveParams,
   ClimateParams,
+  EcmwfParams,
   ElevationParams,
   ElevationResponse,
   EnsembleParams,
@@ -113,7 +114,7 @@ export class OpenMeteoClient {
     return response.data;
   }
 
-  async getEcmwf(params: ForecastParams): Promise<WeatherResponse> {
+  async getEcmwf(params: EcmwfParams): Promise<WeatherResponse> {
     const response = await this.client.get('/v1/ecmwf', {
       params: this.buildParams(params),
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   AirQualityParamsSchema,
   ArchiveParamsSchema,
   ClimateParamsSchema,
+  EcmwfParamsSchema,
   ElevationParamsSchema,
   EnsembleParamsSchema,
   FloodParamsSchema,
@@ -144,7 +145,7 @@ class OpenMeteoMCPServer {
             break;
           }
           case 'ecmwf_forecast': {
-            const params = ForecastParamsSchema.parse(args);
+            const params = EcmwfParamsSchema.parse(args);
             result = await this.client.getEcmwf(params);
             break;
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,58 +201,59 @@ export const DailyVariablesSchema = z
   .optional();
 
 export const ForecastModelsSchema = z
-  .array(
-    z.enum([
-      'ecmwf_ifs_hres_9km',
-      'ecmwf_ifs_025',
-      'ecmwf_aifs_025_single',
-      'cma_grapes_global',
-      'bom_access_global',
-      'ncep_gfs_seamless',
-      'ncep_gfs_global',
-      'ncep_hrrr_us_conus',
-      'ncep_nbm_us_conus',
-      'ncep_nam_us_conus',
-      'ncep_gfs_graphcast',
-      'ncep_aigfs_025',
-      'ncep_hgefs_025_ensemble_mean',
-      'jma_seamless',
-      'jma_msm',
-      'jma_gsm',
-      'kma_seamless',
-      'kma_ldps',
-      'kma_gdps',
-      'dwd_icon_seamless',
-      'dwd_icon_global',
-      'dwd_icon_eu',
-      'dwd_icon_d2',
-      'gem_seamless',
-      'gem_global',
-      'gem_regional',
-      'gem_hrdps_continental',
-      'gem_hrdps_west',
-      'meteofrance_seamless',
-      'meteofrance_arpege_world',
-      'meteofrance_arpege_europe',
-      'meteofrance_arome_france',
-      'meteofrance_arome_france_hd',
-      'italiameteo_arpae_icon_2i',
-      'met_norway_nordic_seamless',
-      'met_norway_nordic',
-      'knmi_seamless',
-      'knmi_harmonie_arome_europe',
-      'knmi_harmonie_arome_netherlands',
-      'dmi_seamless',
-      'dmi_harmonie_arome_europe',
-      'uk_met_office_seamless',
-      'uk_met_office_global_10km',
-      'uk_met_office_uk_2km',
-      'meteoswiss_icon_seamless',
-      'meteoswiss_icon_ch1',
-      'meteoswiss_icon_ch2',
-    ]),
-  )
+  .enum([
+    'ecmwf_ifs_hres_9km',
+    'ecmwf_ifs_025',
+    'ecmwf_aifs_025_single',
+    'cma_grapes_global',
+    'bom_access_global',
+    'ncep_gfs_seamless',
+    'ncep_gfs_global',
+    'ncep_hrrr_us_conus',
+    'ncep_nbm_us_conus',
+    'ncep_nam_us_conus',
+    'ncep_gfs_graphcast',
+    'ncep_aigfs_025',
+    'ncep_hgefs_025_ensemble_mean',
+    'jma_seamless',
+    'jma_msm',
+    'jma_gsm',
+    'kma_seamless',
+    'kma_ldps',
+    'kma_gdps',
+    'dwd_icon_seamless',
+    'dwd_icon_global',
+    'dwd_icon_eu',
+    'dwd_icon_d2',
+    'gem_seamless',
+    'gem_global',
+    'gem_regional',
+    'gem_hrdps_continental',
+    'gem_hrdps_west',
+    'meteofrance_seamless',
+    'meteofrance_arpege_world',
+    'meteofrance_arpege_europe',
+    'meteofrance_arome_france',
+    'meteofrance_arome_france_hd',
+    'italiameteo_arpae_icon_2i',
+    'met_norway_nordic_seamless',
+    'met_norway_nordic',
+    'knmi_seamless',
+    'knmi_harmonie_arome_europe',
+    'knmi_harmonie_arome_netherlands',
+    'dmi_seamless',
+    'dmi_harmonie_arome_europe',
+    'uk_met_office_seamless',
+    'uk_met_office_global_10km',
+    'uk_met_office_uk_2km',
+    'meteoswiss_icon_seamless',
+    'meteoswiss_icon_ch1',
+    'meteoswiss_icon_ch2',
+  ])
   .optional();
+
+// Valid model IDs for the dedicated /v1/ecmwf endpoint (different from /v1/forecast)
+export const EcmwfModelsSchema = z.enum(['ecmwf_ifs', 'ecmwf_ifs025', 'best_match']).optional();
 
 export const EnsembleModelsSchema = z
   .array(
@@ -306,6 +307,11 @@ export const ForecastParamsSchema = CoordinateSchema.extend({
     .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)
     .optional(),
   models: ForecastModelsSchema,
+});
+
+// ECMWF-specific parameters schema (uses a different model ID namespace than /v1/forecast)
+export const EcmwfParamsSchema = ForecastParamsSchema.omit({ models: true }).extend({
+  models: EcmwfModelsSchema,
 });
 
 // Archive parameters schema
@@ -686,6 +692,7 @@ export const ElevationResponseSchema = z.object({
 });
 
 export type ForecastParams = z.infer<typeof ForecastParamsSchema>;
+export type EcmwfParams = z.infer<typeof EcmwfParamsSchema>;
 export type ArchiveParams = z.infer<typeof ArchiveParamsSchema>;
 export type AirQualityParams = z.infer<typeof AirQualityParamsSchema>;
 export type MarineParams = z.infer<typeof MarineParamsSchema>;


### PR DESCRIPTION
## Context

Follow-up to #28 (already merged) which updated tool descriptions and JSON schemas in `tools.ts`.

## Problem

After merging #28, three test failures were observed:

| Test | Result | Root cause |
|---|---|---|
| `ecmwf_forecast` with `"ecmwf_ifs"` | `invalid_enum_value` | Not in `ForecastModelsSchema` Zod enum |
| `ecmwf_forecast` with `"ecmwf_ifs_025"` | HTTP 400 | Passes Zod (old enum) but rejected by `/v1/ecmwf` API |
| `ecmwf_forecast` with `"best_match"` | `invalid_enum_value` | Not in `ForecastModelsSchema` Zod enum |

The previous PR only updated the JSON Schema in `tools.ts` (used for MCP tool descriptions), but **the Zod runtime validation in `types.ts`** was not updated — Zod validates inputs before they ever reach the HTTP API.

## Changes

### `src/types.ts`
- `ForecastModelsSchema`: changed from `z.array(z.enum([...]))` → `z.enum([...])` (single value, matches the updated JSON schema)
- Added `EcmwfModelsSchema`: `z.enum(['ecmwf_ifs', 'ecmwf_ifs025', 'best_match'])` — only model IDs verified to work on `/v1/ecmwf`
- Added `EcmwfParamsSchema`: extends `ForecastParamsSchema` with the ECMWF-specific models enum
- Exported `EcmwfParams` type

### `src/client.ts`
- `getEcmwf()` now accepts `EcmwfParams` instead of `ForecastParams`

### `src/index.ts`
- `ecmwf_forecast` case now parses with `EcmwfParamsSchema` instead of `ForecastParamsSchema`

## Test plan

- [ ] `ecmwf_forecast` with `"ecmwf_ifs"` → should return 200 ✅
- [ ] `ecmwf_forecast` with `"ecmwf_ifs025"` → should return 200 ✅
- [ ] `ecmwf_forecast` with `"best_match"` → should return 200 ✅
- [ ] `ecmwf_forecast` with `"ecmwf_ifs_025"` → should return `invalid_enum_value` (blocked at Zod, never reaches API) ✅
- [ ] `weather_forecast` with a single model string → should return 200 ✅
- [ ] `npm run typecheck` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)