### PR TITLE
fix: map Axios HTTP errors to typed MCP error responses

### DIFF
--- a/docs/superpowers/plans/2026-03-20-http-error-handling.md
+++ b/docs/superpowers/plans/2026-03-20-http-error-handling.md
@@ -1,0 +1,228 @@
+# HTTP Error Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add typed HTTP error handling to `OpenMeteoClient` so that 400, 422, 429, and 5xx errors from Open-Meteo APIs produce structured, actionable messages instead of raw Axios error strings.
+
+**Architecture:** A single `errorInterceptor` function is defined in a private `setupErrorInterceptors()` method on `OpenMeteoClient` and registered on all 9 Axios instances. The interceptor maps HTTP status codes to human-readable error messages. No changes outside `src/client.ts`.
+
+**Tech Stack:** TypeScript, Axios 1.x (`axios.isAxiosError()`), Vitest 4.x
+
+---
+
+## File Map
+
+- **Modify:** `src/client.ts` — add `setupErrorInterceptors()` private method, call it in the constructor
+- **Create:** `src/client.test.ts` — unit tests for the interceptor behavior
+
+---
+
+### Task 1: Write failing tests for the error interceptor
+
+**Files:**
+- Create: `src/client.test.ts`
+
+- [ ] **Step 1: Create `src/client.test.ts` with failing tests**
+
+```typescript
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenMeteoClient } from './client.js';
+
+describe('OpenMeteoClient error interceptor', () => {
+  let client: OpenMeteoClient;
+
+  beforeEach(() => {
+    client = new OpenMeteoClient();
+  });
+
+  it('throws structured message on HTTP 400', async () => {
+    const axiosError = Object.assign(new Error('Bad Request'), {
+      isAxiosError: true,
+      response: { status: 400, data: { reason: 'Invalid latitude' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 999, longitude: 0 }),
+    ).rejects.toThrow('Invalid request parameters: Invalid latitude');
+  });
+
+  it('throws structured message on HTTP 422', async () => {
+    const axiosError = Object.assign(new Error('Unprocessable Entity'), {
+      isAxiosError: true,
+      response: { status: 422, data: { error: 'Cannot initialize model for given coordinates' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 0, longitude: 0 }),
+    ).rejects.toThrow('Invalid parameter value: Cannot initialize model for given coordinates');
+  });
+
+  it('throws structured message on HTTP 429', async () => {
+    const axiosError = Object.assign(new Error('Too Many Requests'), {
+      isAxiosError: true,
+      response: { status: 429, data: {} },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Open-Meteo rate limit reached. Please retry later.');
+  });
+
+  it('throws structured message on HTTP 500', async () => {
+    const axiosError = Object.assign(new Error('Internal Server Error'), {
+      isAxiosError: true,
+      response: { status: 500, data: { reason: 'Upstream failure' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Open-Meteo server error (500): Upstream failure');
+  });
+
+  it('relays non-Axios errors unchanged', async () => {
+    const networkError = new Error('Network timeout');
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(networkError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Network timeout');
+  });
+
+  it('applies to archiveClient (HTTP 400)', async () => {
+    const axiosError = Object.assign(new Error('Bad Request'), {
+      isAxiosError: true,
+      response: { status: 400, data: { reason: 'Invalid date range' } },
+    });
+    vi.spyOn(
+      (client as unknown as { archiveClient: { get: unknown } }).archiveClient,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getArchive({ latitude: 48.8566, longitude: 2.3522, start_date: 'bad', end_date: 'bad' }),
+    ).rejects.toThrow('Invalid request parameters: Invalid date range');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they all fail**
+
+```bash
+npm test -- src/client.test.ts
+```
+
+Expected: All 6 tests FAIL (interceptor does not exist yet).
+
+---
+
+### Task 2: Implement the error interceptor
+
+**Files:**
+- Modify: `src/client.ts:30-67` (constructor and class body)
+
+- [ ] **Step 3: Add `setupErrorInterceptors()` and call it in the constructor**
+
+In `src/client.ts`, after line 66 (`this.climateClient = axios.create(...)`), add a call to the new method, and add the method itself inside the class:
+
+```typescript
+// At the end of the constructor, after all this.xxxClient = axios.create(...) lines:
+this.setupErrorInterceptors();
+```
+
+```typescript
+// New private method to add inside the class, after the constructor:
+private setupErrorInterceptors(): void {
+  const errorInterceptor = (error: unknown) => {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const data = error.response?.data as Record<string, unknown> | undefined;
+      const apiMessage =
+        (data?.reason as string | undefined) ??
+        (data?.error as string | undefined) ??
+        error.message;
+
+      if (status === 400) throw new Error(`Invalid request parameters: ${apiMessage}`);
+      if (status === 422) throw new Error(`Invalid parameter value: ${apiMessage}`);
+      if (status === 429) throw new Error('Open-Meteo rate limit reached. Please retry later.');
+      if (status !== undefined && status >= 500)
+        throw new Error(`Open-Meteo server error (${status}): ${apiMessage}`);
+    }
+    return Promise.reject(error);
+  };
+
+  for (const instance of [
+    this.client,
+    this.airQualityClient,
+    this.marineClient,
+    this.archiveClient,
+    this.seasonalClient,
+    this.ensembleClient,
+    this.geocodingClient,
+    this.floodClient,
+    this.climateClient,
+  ]) {
+    instance.interceptors.response.use(undefined, errorInterceptor);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they all pass**
+
+```bash
+npm test -- src/client.test.ts
+```
+
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Run the full test suite to verify no regressions**
+
+```bash
+npm test
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Type-check**
+
+```bash
+npm run typecheck
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/client.ts src/client.test.ts
+git commit -m "fix: map Axios HTTP errors to typed MCP error responses (#40)"
+```
+
+---
+
+## Verification
+
+After all tasks are complete:
+
+1. `npm test` — all tests pass including the 6 new ones in `src/client.test.ts`
+2. `npm run typecheck` — no TypeScript errors
+3. `npm run lint` — no lint errors

--- a/docs/superpowers/specs/2026-03-20-http-error-handling-design.md
+++ b/docs/superpowers/specs/2026-03-20-http-error-handling-design.md
@@ -1,0 +1,63 @@
+# Design: Typed HTTP Error Handling via Axios Interceptor
+
+**Date:** 2026-03-20
+**Issue:** https://github.com/cmer81/open-meteo-mcp/issues/40
+**Status:** Approved
+
+## Problem
+
+HTTP errors from the Open-Meteo API (400, 422, 429, 500) bubble up as opaque Axios errors and are caught by the generic handler in `index.ts`, which returns raw error messages like `Request failed with status code 429` to the LLM. These messages provide no actionable information.
+
+## Goal
+
+Translate HTTP errors from all Open-Meteo API calls into structured, human-readable messages that allow the LLM to understand what went wrong and self-correct.
+
+## Approach
+
+**Axios response interceptor** applied once to all 9 client instances in `OpenMeteoClient`. A single shared interceptor function is defined and registered via `setupErrorInterceptors()`, called at the end of the constructor.
+
+This is idiomatic Axios, requires no changes outside `client.ts`, and automatically covers any future client instances added to the class.
+
+## Error Mapping
+
+| HTTP Status | Error Message |
+|---|---|
+| 400 | `Invalid request parameters: <apiMessage>` |
+| 422 | `Invalid parameter value: <apiMessage>` |
+| 429 | `Open-Meteo rate limit reached. Please retry later.` |
+| 5xx | `Open-Meteo server error (<status>): <apiMessage>` |
+| Other | Relayed as-is via `Promise.reject` |
+
+`apiMessage` is extracted from `error.response?.data?.reason ?? error.response?.data?.error ?? error.message`, covering known Open-Meteo API response formats.
+
+## Implementation
+
+### Changes to `src/client.ts`
+
+1. Add a private method `setupErrorInterceptors()` that:
+   - Defines a single `errorInterceptor` function
+   - Applies it to all 9 Axios instances via `for...of`
+2. Call `this.setupErrorInterceptors()` at the end of the constructor
+
+No changes to `index.ts`, `security.ts`, or any other file. The generic catch block in `index.ts` (line 191) continues to work unchanged but now receives structured error messages.
+
+### New client instances
+
+Any new Axios client added to `OpenMeteoClient` in the future must be added to the array inside `setupErrorInterceptors()`.
+
+## Testing
+
+New unit tests covering:
+- HTTP 400 → `Invalid request parameters: ...`
+- HTTP 422 → `Invalid parameter value: ...`
+- HTTP 429 → `Open-Meteo rate limit reached. Please retry later.`
+- HTTP 500 → `Open-Meteo server error (500): ...`
+- Non-Axios error → relayed unchanged
+
+Tests use Axios mock adapters or `vi.spyOn` on the client instances. Test file: `src/client.test.ts` (new file).
+
+## Out of Scope
+
+- Retry logic for 429 or 5xx
+- Changes to `index.ts` error formatting
+- Logging of HTTP error details (already handled by the generic catch in `index.ts`)

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -18,9 +18,9 @@ describe('OpenMeteoClient error interceptor', () => {
       'get',
     ).mockRejectedValueOnce(axiosError);
 
-    await expect(
-      client.getForecast({ latitude: 999, longitude: 0 }),
-    ).rejects.toThrow('Invalid request parameters: Invalid latitude');
+    await expect(client.getForecast({ latitude: 999, longitude: 0 })).rejects.toThrow(
+      'Invalid request parameters: Invalid latitude',
+    );
   });
 
   it('throws structured message on HTTP 422', async () => {
@@ -33,9 +33,9 @@ describe('OpenMeteoClient error interceptor', () => {
       'get',
     ).mockRejectedValueOnce(axiosError);
 
-    await expect(
-      client.getForecast({ latitude: 0, longitude: 0 }),
-    ).rejects.toThrow('Invalid parameter value: Cannot initialize model for given coordinates');
+    await expect(client.getForecast({ latitude: 0, longitude: 0 })).rejects.toThrow(
+      'Invalid parameter value: Cannot initialize model for given coordinates',
+    );
   });
 
   it('throws structured message on HTTP 429', async () => {
@@ -48,9 +48,9 @@ describe('OpenMeteoClient error interceptor', () => {
       'get',
     ).mockRejectedValueOnce(axiosError);
 
-    await expect(
-      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
-    ).rejects.toThrow('Open-Meteo rate limit reached. Please retry later.');
+    await expect(client.getForecast({ latitude: 48.8566, longitude: 2.3522 })).rejects.toThrow(
+      'Open-Meteo rate limit reached. Please retry later.',
+    );
   });
 
   it('throws structured message on HTTP 500', async () => {
@@ -63,9 +63,9 @@ describe('OpenMeteoClient error interceptor', () => {
       'get',
     ).mockRejectedValueOnce(axiosError);
 
-    await expect(
-      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
-    ).rejects.toThrow('Open-Meteo server error (500): Upstream failure');
+    await expect(client.getForecast({ latitude: 48.8566, longitude: 2.3522 })).rejects.toThrow(
+      'Open-Meteo server error (500): Upstream failure',
+    );
   });
 
   it('relays non-Axios errors unchanged', async () => {
@@ -75,9 +75,9 @@ describe('OpenMeteoClient error interceptor', () => {
       'get',
     ).mockRejectedValueOnce(networkError);
 
-    await expect(
-      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
-    ).rejects.toThrow('Network timeout');
+    await expect(client.getForecast({ latitude: 48.8566, longitude: 2.3522 })).rejects.toThrow(
+      'Network timeout',
+    );
   });
 
   it('applies to archiveClient (HTTP 400)', async () => {
@@ -91,7 +91,12 @@ describe('OpenMeteoClient error interceptor', () => {
     ).mockRejectedValueOnce(axiosError);
 
     await expect(
-      client.getArchive({ latitude: 48.8566, longitude: 2.3522, start_date: 'bad', end_date: 'bad' }),
+      client.getArchive({
+        latitude: 48.8566,
+        longitude: 2.3522,
+        start_date: 'bad',
+        end_date: 'bad',
+      }),
     ).rejects.toThrow('Invalid request parameters: Invalid date range');
   });
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenMeteoClient } from './client.js';
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,98 @@
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenMeteoClient } from './client.js';
+
+describe('OpenMeteoClient error interceptor', () => {
+  let client: OpenMeteoClient;
+
+  beforeEach(() => {
+    client = new OpenMeteoClient();
+  });
+
+  it('throws structured message on HTTP 400', async () => {
+    const axiosError = Object.assign(new Error('Bad Request'), {
+      isAxiosError: true,
+      response: { status: 400, data: { reason: 'Invalid latitude' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 999, longitude: 0 }),
+    ).rejects.toThrow('Invalid request parameters: Invalid latitude');
+  });
+
+  it('throws structured message on HTTP 422', async () => {
+    const axiosError = Object.assign(new Error('Unprocessable Entity'), {
+      isAxiosError: true,
+      response: { status: 422, data: { error: 'Cannot initialize model for given coordinates' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 0, longitude: 0 }),
+    ).rejects.toThrow('Invalid parameter value: Cannot initialize model for given coordinates');
+  });
+
+  it('throws structured message on HTTP 429', async () => {
+    const axiosError = Object.assign(new Error('Too Many Requests'), {
+      isAxiosError: true,
+      response: { status: 429, data: {} },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Open-Meteo rate limit reached. Please retry later.');
+  });
+
+  it('throws structured message on HTTP 500', async () => {
+    const axiosError = Object.assign(new Error('Internal Server Error'), {
+      isAxiosError: true,
+      response: { status: 500, data: { reason: 'Upstream failure' } },
+    });
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Open-Meteo server error (500): Upstream failure');
+  });
+
+  it('relays non-Axios errors unchanged', async () => {
+    const networkError = new Error('Network timeout');
+    vi.spyOn(
+      (client as unknown as { client: { get: unknown } }).client,
+      'get',
+    ).mockRejectedValueOnce(networkError);
+
+    await expect(
+      client.getForecast({ latitude: 48.8566, longitude: 2.3522 }),
+    ).rejects.toThrow('Network timeout');
+  });
+
+  it('applies to archiveClient (HTTP 400)', async () => {
+    const axiosError = Object.assign(new Error('Bad Request'), {
+      isAxiosError: true,
+      response: { status: 400, data: { reason: 'Invalid date range' } },
+    });
+    vi.spyOn(
+      (client as unknown as { archiveClient: { get: unknown } }).archiveClient,
+      'get',
+    ).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      client.getArchive({ latitude: 48.8566, longitude: 2.3522, start_date: 'bad', end_date: 'bad' }),
+    ).rejects.toThrow('Invalid request parameters: Invalid date range');
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,24 +69,6 @@ export class OpenMeteoClient {
   }
 
   private setupErrorInterceptors(): void {
-    const errorInterceptor = (error: unknown) => {
-      if (axios.isAxiosError(error)) {
-        const status = error.response?.status;
-        const data = error.response?.data as Record<string, unknown> | undefined;
-        const apiMessage =
-          (data?.reason as string | undefined) ??
-          (data?.error as string | undefined) ??
-          error.message;
-
-        if (status === 400) throw new Error(`Invalid request parameters: ${apiMessage}`);
-        if (status === 422) throw new Error(`Invalid parameter value: ${apiMessage}`);
-        if (status === 429) throw new Error('Open-Meteo rate limit reached. Please retry later.');
-        if (status !== undefined && status >= 500)
-          throw new Error(`Open-Meteo server error (${status}): ${apiMessage}`);
-      }
-      return Promise.reject(error);
-    };
-
     for (const instance of [
       this.client,
       this.airQualityClient,
@@ -98,7 +80,7 @@ export class OpenMeteoClient {
       this.floodClient,
       this.climateClient,
     ]) {
-      instance.interceptors.response.use(undefined, errorInterceptor);
+      instance.interceptors.response.use(undefined, OpenMeteoClient.mapHttpError);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -64,6 +64,60 @@ export class OpenMeteoClient {
     this.geocodingClient = axios.create({ baseURL: geocodingURL, ...config });
     this.floodClient = axios.create({ baseURL: floodURL, ...config });
     this.climateClient = axios.create({ baseURL: climateURL, ...config });
+
+    this.setupErrorInterceptors();
+  }
+
+  private setupErrorInterceptors(): void {
+    const errorInterceptor = (error: unknown) => {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const data = error.response?.data as Record<string, unknown> | undefined;
+        const apiMessage =
+          (data?.reason as string | undefined) ??
+          (data?.error as string | undefined) ??
+          error.message;
+
+        if (status === 400) throw new Error(`Invalid request parameters: ${apiMessage}`);
+        if (status === 422) throw new Error(`Invalid parameter value: ${apiMessage}`);
+        if (status === 429) throw new Error('Open-Meteo rate limit reached. Please retry later.');
+        if (status !== undefined && status >= 500)
+          throw new Error(`Open-Meteo server error (${status}): ${apiMessage}`);
+      }
+      return Promise.reject(error);
+    };
+
+    for (const instance of [
+      this.client,
+      this.airQualityClient,
+      this.marineClient,
+      this.archiveClient,
+      this.seasonalClient,
+      this.ensembleClient,
+      this.geocodingClient,
+      this.floodClient,
+      this.climateClient,
+    ]) {
+      instance.interceptors.response.use(undefined, errorInterceptor);
+    }
+  }
+
+  private static mapHttpError(error: unknown): never {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const data = error.response?.data as Record<string, unknown> | undefined;
+      const apiMessage =
+        (data?.reason as string | undefined) ??
+        (data?.error as string | undefined) ??
+        error.message;
+
+      if (status === 400) throw new Error(`Invalid request parameters: ${apiMessage}`);
+      if (status === 422) throw new Error(`Invalid parameter value: ${apiMessage}`);
+      if (status === 429) throw new Error('Open-Meteo rate limit reached. Please retry later.');
+      if (status !== undefined && status >= 500)
+        throw new Error(`Open-Meteo server error (${status}): ${apiMessage}`);
+    }
+    throw error;
   }
 
   private buildParams(params: Record<string, unknown>): Record<string, string> {
@@ -83,121 +137,121 @@ export class OpenMeteoClient {
   }
 
   async getForecast(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/forecast', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/forecast', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getArchive(params: ArchiveParams): Promise<WeatherResponse> {
-    const response = await this.archiveClient.get('/v1/archive', {
-      params: this.buildParams(params),
-    });
+    const response = await this.archiveClient
+      .get('/v1/archive', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getDwdIcon(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/dwd-icon', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/dwd-icon', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getGfs(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/gfs', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/gfs', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getMeteoFrance(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/meteofrance', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/meteofrance', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getEcmwf(params: EcmwfParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/ecmwf', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/ecmwf', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getJma(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/jma', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/jma', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getMetno(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/metno', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/metno', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getGem(params: ForecastParams): Promise<WeatherResponse> {
-    const response = await this.client.get('/v1/gem', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/gem', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getAirQuality(params: AirQualityParams): Promise<WeatherResponse> {
-    const response = await this.airQualityClient.get('/v1/air-quality', {
-      params: this.buildParams(params),
-    });
+    const response = await this.airQualityClient
+      .get('/v1/air-quality', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getMarine(params: MarineParams): Promise<WeatherResponse> {
-    const response = await this.marineClient.get('/v1/marine', {
-      params: this.buildParams(params),
-    });
+    const response = await this.marineClient
+      .get('/v1/marine', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getEnsemble(params: EnsembleParams): Promise<WeatherResponse> {
-    const response = await this.ensembleClient.get('/v1/ensemble', {
-      params: this.buildParams(params),
-    });
+    const response = await this.ensembleClient
+      .get('/v1/ensemble', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getElevation(params: ElevationParams): Promise<ElevationResponse> {
-    const response = await this.client.get('/v1/elevation', {
-      params: this.buildParams(params),
-    });
+    const response = await this.client
+      .get('/v1/elevation', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getFlood(params: FloodParams): Promise<WeatherResponse> {
-    const response = await this.floodClient.get('/v1/flood', {
-      params: this.buildParams(params),
-    });
+    const response = await this.floodClient
+      .get('/v1/flood', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getSeasonal(params: SeasonalParams): Promise<WeatherResponse> {
-    const response = await this.seasonalClient.get('/v1/seasonal', {
-      params: this.buildParams(params),
-    });
+    const response = await this.seasonalClient
+      .get('/v1/seasonal', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getClimate(params: ClimateParams): Promise<WeatherResponse> {
-    const response = await this.climateClient.get('/v1/climate', {
-      params: this.buildParams(params),
-    });
+    const response = await this.climateClient
+      .get('/v1/climate', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 
   async getGeocoding(params: GeocodingParams): Promise<GeocodingResponse> {
-    const response = await this.geocodingClient.get('/v1/search', {
-      params: this.buildParams(params),
-    });
+    const response = await this.geocodingClient
+      .get('/v1/search', { params: this.buildParams(params) })
+      .catch(OpenMeteoClient.mapHttpError);
     return response.data;
   }
 }


### PR DESCRIPTION
Closes #40

## Summary

- Add `mapHttpError()` static method to `OpenMeteoClient` mapping HTTP 400/422/429/5xx to structured, actionable error messages
- Add `setupErrorInterceptors()` registering the mapping on all 9 Axios instances
- Apply `.catch(OpenMeteoClient.mapHttpError)` to all 17 public API methods for full coverage
- Add `src/client.test.ts` with 6 unit tests covering all error codes and multi-client coverage

## Error mapping

| Status | Message |
|---|---|
| 400 | `Invalid request parameters: <reason>` |
| 422 | `Invalid parameter value: <reason>` |
| 429 | `Open-Meteo rate limit reached. Please retry later.` |
| 5xx | `Open-Meteo server error (<status>): <reason>` |

## Test Plan

- [x] 6 new unit tests in `src/client.test.ts` — all passing
- [x] 152 total tests passing, no regressions
- [x] TypeScript typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)