### PR TITLE
Add tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -192,6 +192,12 @@ const ENSEMBLE_HOURLY_VARIABLES = [
 
 export const WEATHER_FORECAST_TOOL: Tool = {
   name: 'weather_forecast',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get weather forecast data for coordinates using Open-Meteo API. Supports hourly and daily data with various weather variables. When no `models` parameter is provided, the API automatically selects the best model for the given location (recommended). Only one model per request is supported — for multi-model comparison, use provider-specific tools with parallel calls.',
   inputSchema: {
@@ -449,6 +455,12 @@ export const WEATHER_FORECAST_TOOL: Tool = {
 
 export const WEATHER_ARCHIVE_TOOL: Tool = {
   name: 'weather_archive',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get historical weather data from ERA5 reanalysis (1940-present) for specific coordinates and date range.',
   inputSchema: {
@@ -657,6 +669,12 @@ export const WEATHER_ARCHIVE_TOOL: Tool = {
 
 export const AIR_QUALITY_TOOL: Tool = {
   name: 'air_quality',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get air quality forecast data including PM2.5, PM10, ozone, nitrogen dioxide, pollen, European/US AQI indices, UV index and other pollutants.',
   inputSchema: {
@@ -795,6 +813,12 @@ export const AIR_QUALITY_TOOL: Tool = {
 
 export const MARINE_WEATHER_TOOL: Tool = {
   name: 'marine_weather',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get marine weather forecast including wave height, wave period, wave direction and sea surface temperature.',
   inputSchema: {
@@ -924,6 +948,12 @@ export const MARINE_WEATHER_TOOL: Tool = {
 
 export const ELEVATION_TOOL: Tool = {
   name: 'elevation',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get elevation data for given coordinates using digital elevation models. Supports batch lookups: pass arrays of the same length for latitude and longitude to query multiple points in one call.',
   inputSchema: {
@@ -967,6 +997,12 @@ function scopedModelForecastSchema(models: string[], description: string): Tool[
 export const WEATHER_MODEL_TOOLS: Tool[] = [
   {
     name: 'dwd_icon_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from German DWD ICON model. IMPORTANT: Specify exactly one DWD model in the `models` parameter (e.g., "dwd_icon_global") — only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -985,6 +1021,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'gfs_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from US NOAA GFS model. IMPORTANT: Specify exactly one GFS model in the `models` parameter (e.g., "ncep_gfs_global") — only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1004,6 +1046,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'meteofrance_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from French Météo-France models. IMPORTANT: Specify exactly one Météo-France model in the `models` parameter (e.g., "meteofrance_arome_france" or "meteofrance_arpege_europe") — only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1019,6 +1067,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'ecmwf_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from ECMWF models via the dedicated /v1/ecmwf endpoint. IMPORTANT: Specify exactly one model in the `models` parameter — only one model per request is supported. Valid model IDs for this endpoint are: "ecmwf_ifs" (IFS HRES, high-resolution), "ecmwf_ifs025" (IFS open-data at 0.25°), "best_match". Note: "ecmwf_ifs_025", "ecmwf_ifs_hres_9km", and "ecmwf_aifs_025_single" are NOT valid on this endpoint and will return 400. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1028,6 +1082,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'jma_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from Japan Meteorological Agency (JMA) models. IMPORTANT: Specify exactly one JMA model in the `models` parameter (e.g., "jma_msm" or "jma_gsm") — only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1037,6 +1097,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'metno_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from Norwegian Meteorological Institute models. The `models` parameter is optional for this tool — omit it to use the default Met.no model. If specified, use canonical names such as "metno_nordic" or "metno_seamless". Only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1046,6 +1112,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
   },
   {
     name: 'gem_forecast',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     description:
       'Get weather forecast from Canadian Meteorological Centre (GEM) models. IMPORTANT: Specify exactly one GEM model in the `models` parameter (e.g., "gem_global" or "gem_regional") — only one model per request is supported. For multi-model comparison, make one parallel tool call per model using the appropriate provider-specific tool.',
     inputSchema: scopedModelForecastSchema(
@@ -1068,6 +1140,12 @@ export const WEATHER_MODEL_TOOLS: Tool[] = [
 
 export const FLOOD_FORECAST_TOOL: Tool = {
   name: 'flood_forecast',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get river discharge and flood forecasts from GloFAS (Global Flood Awareness System).',
   inputSchema: {
@@ -1163,6 +1241,12 @@ export const FLOOD_FORECAST_TOOL: Tool = {
 
 export const SEASONAL_FORECAST_TOOL: Tool = {
   name: 'seasonal_forecast',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Get long-range seasonal forecasts for temperature and precipitation up to ~7 months ahead.',
   inputSchema: {
@@ -1497,6 +1581,12 @@ export const SEASONAL_FORECAST_TOOL: Tool = {
 
 export const CLIMATE_PROJECTION_TOOL: Tool = {
   name: 'climate_projection',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description: 'Get climate change projections from CMIP6 models for different warming scenarios.',
   inputSchema: {
     type: 'object',
@@ -1626,6 +1716,12 @@ export const CLIMATE_PROJECTION_TOOL: Tool = {
 
 export const ENSEMBLE_FORECAST_TOOL: Tool = {
   name: 'ensemble_forecast',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description: 'Get ensemble forecasts showing forecast uncertainty with multiple model runs.',
   inputSchema: {
     type: 'object',
@@ -1842,6 +1938,12 @@ export const ENSEMBLE_FORECAST_TOOL: Tool = {
 
 export const GEOCODING_TOOL: Tool = {
   name: 'geocoding',
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
   description:
     'Search for locations worldwide by place name or postal code. Returns geographic coordinates (latitude and longitude) and detailed location information. Use this tool when you need to convert a location name (e.g., "Paris", "New York") into precise coordinates (latitude/longitude) that are required by other tools. This is essential when you have a location name but need coordinates for data fetching tools.',
   inputSchema: {


### PR DESCRIPTION
## Summary
- Adds MCP tool annotations to all 17 tools in `src/tools.ts`.
- Every tool is a pure read-only query against an Open-Meteo endpoint, so all are annotated `readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true`.
- Follows the `anthropics/skills@mcp-builder` best-practices guide, which recommends annotations so MCP clients can decide whether a tool call needs user confirmation.

This is PR 1 of 4 from an audit against MCP best practices. It has no functional impact — annotations are metadata only.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 153 tests passing
- [x] `npm run build` — passes
- [x] `biome lint src/` — 0 errors