### PR TITLE
Enforce .strict() on tool input schemas

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
 // Base parameter schemas
-export const CoordinateSchema = z.object({
-  latitude: z.number().min(-90).max(90),
-  longitude: z.number().min(-180).max(180),
-});
+export const CoordinateSchema = z
+  .object({
+    latitude: z.number().min(-90).max(90),
+    longitude: z.number().min(-180).max(180),
+  })
+  .strict();
 
 export const TemperatureUnitSchema = z.enum(['celsius', 'fahrenheit']).default('celsius');
 export const WindSpeedUnitSchema = z.enum(['kmh', 'ms', 'mph', 'kn']).default('kmh');
@@ -12,16 +14,18 @@ export const PrecipitationUnitSchema = z.enum(['mm', 'inch']).default('mm');
 export const TimeFormatSchema = z.enum(['iso8601', 'unixtime']).default('iso8601');
 
 // Geocoding schemas
-export const GeocodingParamsSchema = z.object({
-  name: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
-  count: z.number().min(1).max(100).default(10).optional(),
-  language: z.string().optional(),
-  countryCode: z
-    .string()
-    .regex(/^[A-Z]{2}$/, 'Le code pays doit être au format ISO-3166-1 alpha2 (ex: FR, DE, US)')
-    .optional(),
-  format: z.enum(['json', 'protobuf']).default('json').optional(),
-});
+export const GeocodingParamsSchema = z
+  .object({
+    name: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
+    count: z.number().min(1).max(100).default(10).optional(),
+    language: z.string().optional(),
+    countryCode: z
+      .string()
+      .regex(/^[A-Z]{2}$/, 'Le code pays doit être au format ISO-3166-1 alpha2 (ex: FR, DE, US)')
+      .optional(),
+    format: z.enum(['json', 'protobuf']).default('json').optional(),
+  })
+  .strict();
 
 export const LocationSchema = z.object({
   id: z.number(),
@@ -1529,10 +1533,12 @@ export const EnsembleParamsSchema = CoordinateSchema.extend({
 
 // Elevation parameters — the API supports batch lookups via comma-separated
 // lat/lon lists, so each coordinate accepts either a single value or an array.
-export const ElevationParamsSchema = z.object({
-  latitude: z.union([z.number().min(-90).max(90), z.array(z.number().min(-90).max(90))]),
-  longitude: z.union([z.number().min(-180).max(180), z.array(z.number().min(-180).max(180))]),
-});
+export const ElevationParamsSchema = z
+  .object({
+    latitude: z.union([z.number().min(-90).max(90), z.array(z.number().min(-90).max(90))]),
+    longitude: z.union([z.number().min(-180).max(180), z.array(z.number().min(-180).max(180))]),
+  })
+  .strict();
 
 // Response types
 export const WeatherResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Adds `.strict()` to `CoordinateSchema`, `GeocodingParamsSchema`, and `ElevationParamsSchema` in `src/types.ts`.
- Every model-specific forecast schema (`ForecastParamsSchema`, `ArchiveParamsSchema`, `EcmwfParamsSchema`, `DwdIconParamsSchema`, etc.) derives from `CoordinateSchema` via `.extend()`/`.omit()`, which preserve the base schema's strict mode in Zod v3 — verified empirically before applying this change. So 3 edits cover all 17 tool input schemas.
- Without `.strict()`, a misspelled or stale parameter from an agent was silently dropped instead of raising a validation error, making mistakes hard to debug. Follows the `mcp-builder` best-practices guide.

**Stacked on #54** (`mcp-audit/tool-annotations`) — merge that one first, or merge this PR's target branch accordingly.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm test` — 153 tests passing (no regression, confirms no existing test relies on extra/unknown fields)
- [x] `npm run build` — passes
- [x] `biome lint src/` — 0 errors