### PR TITLE
Truncate oversized tool responses with a clear message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   sanitizeErrorMessage,
 } from './security.js';
 import { ALL_TOOLS } from './tools.js';
+import { truncateResponse } from './truncation.js';
 import {
   AirQualityParamsSchema,
   ArchiveParamsSchema,
@@ -185,7 +186,7 @@ export class OpenMeteoMCPServer {
             throw new Error(`Unknown tool: ${name}`);
         }
 
-        const responseText = JSON.stringify(result, null, 2);
+        const responseText = JSON.stringify(truncateResponse(result), null, 2);
         log('info', 'tool_success', {
           tool: name,
           response_size: responseText.length,

--- a/src/truncation.test.ts
+++ b/src/truncation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { CHARACTER_LIMIT, truncateResponse } from './truncation.js';
+
+function makeHourlySeries(length: number) {
+  return {
+    time: Array.from({ length }, (_, i) => `2026-01-01T${i}:00`),
+    temperature_2m: Array.from({ length }, (_, i) => i / 10),
+    relative_humidity_2m: Array.from({ length }, (_, i) => 100 - i),
+  };
+}
+
+describe('truncateResponse', () => {
+  it('returns the input unchanged when already within the character limit', () => {
+    const small = { latitude: 48.85, longitude: 2.35, hourly: makeHourlySeries(5) };
+    expect(truncateResponse(small)).toEqual(small);
+  });
+
+  it('returns non-object results unchanged', () => {
+    expect(truncateResponse('just a string')).toBe('just a string');
+    expect(truncateResponse(null)).toBe(null);
+    expect(truncateResponse([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('returns oversized objects unchanged when they have no recognized truncatable shape', () => {
+    const big = { note: 'x'.repeat(CHARACTER_LIMIT + 1000) };
+    expect(truncateResponse(big)).toEqual(big);
+  });
+
+  it('shrinks hourly time-series arrays in sync and stays under the limit', () => {
+    const large = {
+      latitude: 48.85,
+      longitude: 2.35,
+      hourly: makeHourlySeries(20_000),
+    };
+    expect(JSON.stringify(large).length).toBeGreaterThan(CHARACTER_LIMIT);
+
+    const result = truncateResponse(large) as typeof large & {
+      truncated: boolean;
+      truncation_message: string;
+    };
+
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    expect(result.truncated).toBe(true);
+    expect(result.truncation_message).toContain('truncated');
+
+    // All parallel arrays under `hourly` must be shrunk to the exact same length.
+    const lengths = Object.values(result.hourly).map((arr) => (arr as unknown[]).length);
+    expect(new Set(lengths).size).toBe(1);
+    expect(lengths[0]).toBeGreaterThan(0);
+    expect(lengths[0]).toBeLessThan(20_000);
+  });
+
+  it('shrinks a top-level results array (e.g. geocoding) directly', () => {
+    const large = {
+      results: Array.from({ length: 5000 }, (_, i) => ({
+        id: i,
+        name: `City ${i}`,
+        latitude: 0,
+        longitude: 0,
+      })),
+    };
+    expect(JSON.stringify(large).length).toBeGreaterThan(CHARACTER_LIMIT);
+
+    const result = truncateResponse(large) as typeof large & { truncated: boolean };
+
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    expect(result.truncated).toBe(true);
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results.length).toBeLessThan(5000);
+  });
+});

--- a/src/truncation.ts
+++ b/src/truncation.ts
@@ -1,0 +1,68 @@
+// Maximum response size in characters before truncation kicks in.
+export const CHARACTER_LIMIT = 25_000;
+
+// Object-shaped fields whose values are parallel time-series arrays
+// (e.g. hourly.time, hourly.temperature_2m — same length, same index meaning).
+const TIME_SERIES_KEYS = ['hourly', 'daily', 'minutely_15'] as const;
+
+function shrinkArraysInPlace(container: Record<string, unknown>, ratio: number): void {
+  for (const field of Object.keys(container)) {
+    const value = container[field];
+    if (Array.isArray(value)) {
+      container[field] = value.slice(0, Math.max(1, Math.floor(value.length * ratio)));
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Truncates large tool responses so they stay within CHARACTER_LIMIT.
+ *
+ * Weather responses hold parallel time-series arrays under `hourly`/`daily`/
+ * `minutely_15` (one entry per timestamp across several variables); shrinking
+ * them all by the same ratio keeps the series internally consistent. List
+ * responses (e.g. geocoding's `results`) are truncated directly.
+ *
+ * Returns the original value unchanged if it's already within the limit, or
+ * if it has no recognized shape to truncate (nothing is guessed at).
+ */
+export function truncateResponse(result: unknown): unknown {
+  const originalText = JSON.stringify(result);
+  if (originalText.length <= CHARACTER_LIMIT || !isPlainObject(result)) {
+    return result;
+  }
+
+  const seriesKeys = TIME_SERIES_KEYS.filter((key) => isPlainObject(result[key]));
+  const hasResultsArray = Array.isArray(result.results);
+
+  if (seriesKeys.length === 0 && !hasResultsArray) {
+    return result;
+  }
+
+  const clone = structuredClone(result) as Record<string, unknown>;
+  let currentText = originalText;
+
+  for (let attempt = 0; attempt < 5 && currentText.length > CHARACTER_LIMIT; attempt++) {
+    const ratio = CHARACTER_LIMIT / currentText.length;
+    for (const key of seriesKeys) {
+      shrinkArraysInPlace(clone[key] as Record<string, unknown>, ratio);
+    }
+    if (hasResultsArray) {
+      const arr = clone.results as unknown[];
+      clone.results = arr.slice(0, Math.max(1, Math.floor(arr.length * ratio)));
+    }
+    currentText = JSON.stringify(clone);
+  }
+
+  return {
+    ...clone,
+    truncated: true,
+    truncation_message:
+      `Response truncated from ${originalText.length} to ${currentText.length} characters ` +
+      `to stay within the ${CHARACTER_LIMIT}-character limit. Narrow the request (start_date/` +
+      'end_date, forecast_days, past_days, or fewer variables) to retrieve the full data.',
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `src/truncation.ts` with a `CHARACTER_LIMIT` (25,000 chars) guard and a `truncateResponse()` helper, wired into `src/index.ts`'s tool-response path.
- Tools like `weather_forecast`, `weather_archive`, `seasonal_forecast`, or `ensemble_forecast` can return very large payloads (months of hourly data across many variables) with no size cap today — risking a blown context window on the agent side.
- `truncateResponse()` shrinks parallel time-series arrays under `hourly`/`daily`/`minutely_15` by the same ratio so they stay index-aligned (e.g. `hourly.time` and `hourly.temperature_2m` end up the same length), and truncates top-level list responses (`geocoding`'s `results`) directly.
- Adds a `truncated: true` / `truncation_message` field to the response explaining how to narrow the request (`start_date`/`end_date`, `forecast_days`, `past_days`, fewer variables).
- Responses that are already within the limit, or that don't have a recognized array-bearing shape, are returned unchanged — nothing is guessed at.
- Follows the `mcp-builder` best-practices guide's `CHARACTER_LIMIT` pattern.

**Stacked on #55** (`mcp-audit/strict-schemas`) — merge in order: #54 → #55 → this one.

## Test plan
- [x] New `src/truncation.test.ts`: unchanged-when-small, non-object passthrough, unrecognized-shape passthrough, hourly-series shrink stays in sync, geocoding `results` shrink
- [x] `npm run typecheck` — passes
- [x] `npm test` — 158 tests passing (153 existing + 5 new)
- [x] `npm run build` — passes
- [x] `biome lint src/` — 0 errors