### PR TITLE
fix: empty tool schemas, ineffective truncation, and unauthenticated MCP routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,21 @@
 # Set to 'http' for Streamable HTTP mode, omit or leave empty for stdio mode
 TRANSPORT=http
 PORT=3000
+# Interface the HTTP transport binds to. Defaults to 127.0.0.1 (loopback only).
+# Set to 0.0.0.0 to accept connections from outside the machine or container.
+# HOST=127.0.0.1
+
+# HTTP Transport Security (all optional)
+# Require an API key on every /mcp request (Authorization: Bearer <key> or X-API-Key).
+# When unset, the server runs in open mode — suitable for local use only.
+# API_KEY=your-secret-key
+# Requests per minute per client IP (default: 60)
+# RATE_LIMIT_RPM=60
+# Honour X-Forwarded-For only from these proxies. Unset = header always ignored.
+# TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+# Browser origins allowed to reach the server (DNS rebinding protection).
+# Empty by default: any request carrying an Origin header is rejected with 403.
+# ALLOWED_ORIGINS=http://localhost:5173,https://app.example
 
 # Open-Meteo API URLs
 # All are optional with sensible defaults

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ This is an Open-Meteo MCP (Model Context Protocol) server that provides comprehe
 
 - **`src/index.ts`** - Main MCP server implementation using `@modelcontextprotocol/sdk`
 - **`src/client.ts`** - HTTP client with multiple API endpoints (forecast, archive, air quality, marine, etc.)
-- **`src/tools.ts`** - MCP tool definitions with comprehensive JSON schemas
+- **`src/tools.ts`** - Tool metadata (name, title, description, annotations); input schemas come from `types.ts`
 - **`src/types.ts`** - Zod validation schemas for all API parameters and responses
+- **`src/truncation.ts`** - Caps oversized responses and serializes them for the client
+- **`src/security.ts`** - Auth, origin validation, rate limiting, trusted-proxy IP extraction (HTTP transport only)
 
 ### API Client Architecture
 
@@ -32,8 +34,12 @@ Each service can be configured via environment variables with sensible defaults.
 ### Transport Modes
 
 The server supports two transport modes (configured via `TRANSPORT` env var):
-- **stdio** (default) - Standard input/output for direct MCP client integration (Claude Desktop, etc.)
-- **Streamable HTTP** (`TRANSPORT=http`) - Express-based HTTP server with session management, listening on `PORT` (default: 3000) at `/mcp` endpoint
+- **stdio** (default) - Standard input/output for direct MCP client integration (Claude Desktop, etc.). Never write logs to stdout here — it would corrupt the protocol stream; `log()` writes to stderr.
+- **Streamable HTTP** (`TRANSPORT=http`) - Express-based HTTP server with session management, listening on `PORT` (default: 3000) at `/mcp` endpoint, bound to `HOST` (default: `127.0.0.1`, loopback only)
+
+### HTTP middleware ordering
+
+Express runs middleware in declaration order, so every guard must be registered **before** the routes it protects. `createOriginValidator`, `createRateLimiter` and `createAuthMiddleware` are mounted ahead of the `/mcp` GET, POST and DELETE handlers; mounting them later silently leaves the earlier routes unauthenticated. `/health` is declared before the guards on purpose, so container probes work without a key.
 
 ### Tool System
 
@@ -82,6 +88,13 @@ The server uses environment variables for API endpoints with fallback defaults:
 Transport configuration:
 - `TRANSPORT` - Set to `http` to enable Streamable HTTP mode (default: stdio)
 - `PORT` - HTTP server port when using HTTP transport (default: 3000)
+- `HOST` - Interface to bind (default: `127.0.0.1`). Set `0.0.0.0` to accept remote connections; the Docker image already does.
+
+HTTP transport security (all optional, HTTP mode only):
+- `API_KEY` - When set, every `/mcp` request needs `Authorization: Bearer <key>` or `X-API-Key`. Unset = open mode.
+- `RATE_LIMIT_RPM` - Requests per minute per client IP (default: 60)
+- `TRUSTED_PROXIES` - Comma-separated IPs/CIDRs whose `X-Forwarded-For` is trusted. Unset = header ignored.
+- `ALLOWED_ORIGINS` - Comma-separated browser origins allowed (DNS rebinding protection). Empty by default: any request carrying an `Origin` header is rejected with 403. Requests without one are unaffected.
 
 ## Key Implementation Patterns
 
@@ -98,9 +111,16 @@ The `buildParams` method in `OpenMeteoClient` handles parameter serialization:
 - Proper User-Agent headers for API identification
 
 ### Response Formatting
-All tool responses return JSON-stringified weather data with 2-space indentation for readability in LLM contexts.
+All tool responses go through `serializeToolResponse()` (`src/truncation.ts`), which truncates if needed and JSON-stringifies with 2-space indentation. Always use it rather than calling `JSON.stringify` at the call site: truncation measures the text *as emitted*, and indentation roughly doubles the character count, so measuring one form while emitting another lets responses blow past the limit.
+
+Responses over 25,000 characters have their `hourly`/`daily`/`minutely_15` arrays shrunk by an equal ratio (keeping parallel series aligned) or their `results` array trimmed, and gain `truncated: true` plus a `truncation_message`.
+
+### Adding a tool with cross-field validation
+`registerTool` publishes the JSON schema by introspecting the Zod object. A `.refine()`/`.superRefine()` returns a **ZodEffects**, which the SDK cannot introspect — it would publish an empty `{}` input schema while still validating strictly, leaving clients unable to know what to send. `registerReadOnlyTool` therefore unwraps via `.innerType()` for publication and re-applies the full schema (effects included) inside the handler. Keep both halves when adding a tool whose parameters have cross-field rules, such as `start_date <= end_date`.
 
 ## Schema Validation
+
+All param schemas are `.strict()`, so unknown keys are rejected rather than silently forwarded to the upstream API.
 
 Uses Zod for runtime validation of:
 - Coordinate bounds (latitude: -90 to 90, longitude: -180 to 180)

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,8 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 # Run in HTTP mode by default
 ENV TRANSPORT=http
 ENV PORT=3000
+# Bind to all interfaces inside the container so published ports reach the server.
+# The server itself defaults to loopback; the container boundary is the limit here.
+ENV HOST=0.0.0.0
 
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A comprehensive [Model Context Protocol (MCP)](https://modelcontextprotocol.io) 
 This MCP server provides complete access to Open-Meteo APIs, including:
 
 ### Core Weather APIs
-- **Weather Forecast** (`weather_forecast`) - 7-day forecasts with hourly and daily resolution
+- **Weather Forecast** (`weather_forecast`) - Forecasts up to 16 days (7 by default) with hourly and daily resolution
 - **Weather Archive** (`weather_archive`) - Historical ERA5 data from 1940 to present
 - **Air Quality** (`air_quality`) - PM2.5, PM10, ozone, nitrogen dioxide, pollen, European/US AQI indices, UV index and other pollutants
 - **Marine Weather** (`marine_weather`) - Wave height, wave period, wave direction and sea surface temperature
@@ -168,11 +168,15 @@ TRANSPORT=http PORT=3000 npx open-meteo-mcp-server
 
 This starts an Express server on the specified port (default: 3000) with the MCP endpoint at `/mcp`. The HTTP transport supports session management with unique session IDs per client.
 
-For production deployments, enable authentication and rate limiting:
+> **The server binds to `127.0.0.1` by default**, so it is reachable only from the local machine. To accept connections from other hosts, set `HOST=0.0.0.0` explicitly. The Docker image already does this, so published ports work without extra configuration.
+
+For production deployments, bind to a reachable interface and enable authentication and rate limiting:
 
 ```bash
-API_KEY=your-secret-key RATE_LIMIT_RPM=60 TRANSPORT=http PORT=3000 npx open-meteo-mcp-server
+HOST=0.0.0.0 API_KEY=your-secret-key RATE_LIMIT_RPM=60 TRANSPORT=http PORT=3000 npx open-meteo-mcp-server
 ```
+
+If a browser-based client connects to the server, list its origin in `ALLOWED_ORIGINS` — requests carrying an unlisted `Origin` header are rejected with `403` as DNS rebinding protection.
 
 Clients must then include the key in every request:
 ```
@@ -297,12 +301,16 @@ All environment variables are optional and have sensible defaults:
 - `OPEN_METEO_CLIMATE_API_URL` - Climate projection API URL (default: https://climate-api.open-meteo.com)
 - `TRANSPORT` - Transport mode: `http` for Streamable HTTP, omit for stdio (default: stdio)
 - `PORT` - HTTP server port when using HTTP transport (default: 3000)
+- `HOST` - Interface the HTTP transport binds to (default: `127.0.0.1`, loopback only). Set to `0.0.0.0` to accept connections from other machines. The Docker image sets this to `0.0.0.0` already, so published ports work out of the box.
 
 #### HTTP Transport Security (optional)
 
-- `API_KEY` - When set, all requests to `/mcp` must include this key via `Authorization: Bearer <key>` or `X-API-Key: <key>`. Leave unset for open access (local/dev mode).
+- `API_KEY` - When set, all requests to `/mcp` must include this key via `Authorization: Bearer <key>` or `X-API-Key: <key>`. Leave unset for open access (local/dev mode). Enforced on `GET`, `POST` and `DELETE` alike.
 - `RATE_LIMIT_RPM` - Maximum requests per minute per IP (default: `60`). HTTP transport only.
 - `TRUSTED_PROXIES` - Comma-separated list of trusted proxy IPs or CIDR ranges (e.g. `10.0.0.0/8,172.16.0.0/12`). When set, `X-Forwarded-For` is honoured only for requests originating from these addresses. Leave unset to always use the direct connection IP.
+- `ALLOWED_ORIGINS` - Comma-separated list of browser origins permitted to reach the server (e.g. `http://localhost:5173,https://app.example`). Protects against DNS rebinding: any request carrying an `Origin` header that is not listed is rejected with `403`. Requests without an `Origin` header — CLI clients and SDK transports — are unaffected. Empty by default.
+
+`/health` stays reachable without a key and without rate limiting, so container probes keep working.
 
 ## Skills
 
@@ -508,7 +516,8 @@ src/
 ├── client.ts         # HTTP client for Open-Meteo API
 ├── tools.ts          # MCP tool definitions
 ├── types.ts          # Zod validation schemas
-└── security.ts       # Auth middleware, rate limiter, IP extraction
+├── truncation.ts     # Response size capping and serialization
+└── security.ts       # Auth, origin validation, rate limiter, IP extraction
 ```
 
 ## API Coverage
@@ -546,6 +555,19 @@ The server provides comprehensive error handling with detailed error messages fo
 - API rate limits
 - Network connectivity issues
 - Invalid date ranges
+
+### Response Size Limits
+
+Tool responses are capped at 25,000 characters so a single wide query cannot overflow an LLM's context. When a response exceeds the limit, the time-series arrays (`hourly`, `daily`, `minutely_15`) are shortened by an equal ratio — keeping every parallel series aligned on the same timestamps — and two fields are added:
+
+```json
+{
+  "truncated": true,
+  "truncation_message": "Response truncated from 95538 characters to stay within the 25000-character limit. Narrow the request (start_date/end_date, forecast_days, past_days, or fewer variables) to retrieve the full data."
+}
+```
+
+To get complete data, narrow the request: shorter date range, fewer `forecast_days`/`past_days`, or fewer variables.
 
 ## Performance
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,6 +23,10 @@ services:
       # - API_KEY=your-secret-key
       # - RATE_LIMIT_RPM=60
       # - TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+      # Browser origins allowed (DNS rebinding protection). Empty = any request
+      # carrying an Origin header is rejected with 403.
+      # - ALLOWED_ORIGINS=http://localhost:5173
+      # HOST is set to 0.0.0.0 in the image so the published port is reachable.
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       # - API_KEY=your-secret-key
       # - RATE_LIMIT_RPM=60
       # - TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+      # Browser origins allowed (DNS rebinding protection). Empty = any request
+      # carrying an Origin header is rejected with 403.
+      # - ALLOWED_ORIGINS=https://app.example
+      # HOST is set to 0.0.0.0 in the image so the published port is reachable.
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import type express from 'express';
 import supertest from 'supertest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenMeteoClient } from './client.js';
 import { OpenMeteoMCPServer } from './index.js';
 import { ALL_TOOLS } from './tools.js';
@@ -387,5 +387,130 @@ describe('Full protocol round trip via McpServer#registerTool', () => {
     const text = callRes.body.result.content[0].text as string;
     expect(text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
     expect(JSON.parse(text).truncated).toBe(true);
+  });
+});
+
+describe('HTTP transport security', () => {
+  let app: express.Application;
+  const acceptBoth = 'application/json, text/event-stream';
+  const initBody = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' },
+    },
+  };
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    app = (
+      new OpenMeteoMCPServer() as unknown as { buildExpressApp(): express.Application }
+    ).buildExpressApp();
+  });
+
+  afterEach(() => {
+    delete process.env.API_KEY;
+    delete process.env.ALLOWED_ORIGINS;
+  });
+
+  // The auth and rate-limit middlewares used to be registered after the GET and
+  // DELETE routes, so Express never ran them for those two verbs: an unauthenticated
+  // caller holding a session id could terminate someone else's session.
+  describe('API key enforcement', () => {
+    beforeEach(() => {
+      process.env.API_KEY = 'test-secret';
+    });
+
+    it('rejects GET /mcp when no API key is supplied', async () => {
+      const res = await supertest(app).get('/mcp').set('mcp-session-id', 'some-session-id');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects DELETE /mcp when no API key is supplied', async () => {
+      const res = await supertest(app).delete('/mcp').set('mcp-session-id', 'some-session-id');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects POST /mcp when no API key is supplied', async () => {
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', acceptBoth)
+        .send(initBody);
+      expect(res.status).toBe(401);
+    });
+
+    it('lets an authenticated caller through to the route handler', async () => {
+      const res = await supertest(app)
+        .delete('/mcp')
+        .set('X-API-Key', 'test-secret')
+        .set('mcp-session-id', 'unknown-session');
+      // 404 = auth passed, the session simply does not exist
+      expect(res.status).toBe(404);
+    });
+
+    it('leaves /health reachable without a key for container probes', async () => {
+      const res = await supertest(app).get('/health');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // DNS rebinding protection: a browser page on any origin could otherwise drive
+  // a locally bound MCP server.
+  describe('Origin validation', () => {
+    it('rejects a browser Origin when none are allow-listed', async () => {
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', acceptBoth)
+        .set('Origin', 'http://evil.example')
+        .send(initBody);
+      expect(res.status).toBe(403);
+    });
+
+    it('accepts an Origin present in ALLOWED_ORIGINS', async () => {
+      process.env.ALLOWED_ORIGINS = 'http://localhost:5173,https://app.example';
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', acceptBoth)
+        .set('Origin', 'https://app.example')
+        .send(initBody);
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts requests with no Origin header (non-browser clients)', async () => {
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', acceptBoth)
+        .send(initBody);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // The Accept normalizer mutates req.headers, but the SDK reads the raw Node
+  // headers through Hono, so clients sending */* used to get a 406.
+  describe('Accept header normalization', () => {
+    it('accepts a client sending Accept: */*', async () => {
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', '*/*')
+        .send(initBody);
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts a client sending only application/json', async () => {
+      const res = await supertest(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send(initBody);
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OpenMeteoClient } from './client.js';
 import { OpenMeteoMCPServer } from './index.js';
 import { ALL_TOOLS } from './tools.js';
+import { CHARACTER_LIMIT } from './truncation.js';
 import {
   AirQualityParamsSchema,
   ArchiveParamsSchema,
@@ -275,5 +276,116 @@ describe('Full protocol round trip via McpServer#registerTool', () => {
       precipitation_unit: 'mm',
       timeformat: 'iso8601',
     });
+  });
+
+  // Tools whose params schema carries a .refine() used to reach the SDK as a
+  // ZodEffects, which it cannot introspect: it published an empty `{}` schema
+  // while still validating strictly, leaving clients unable to know what to send.
+  it('publishes a complete input schema for every tool', async () => {
+    const acceptBoth = 'application/json, text/event-stream';
+    const initRes = await supertest(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', acceptBoth)
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      });
+    const sessionId = initRes.headers['mcp-session-id'];
+
+    const listRes = await supertest(app)
+      .post('/mcp')
+      .set('mcp-session-id', sessionId)
+      .set('Content-Type', 'application/json')
+      .set('Accept', acceptBoth)
+      .send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+
+    const tools = listRes.body.result.tools as Array<{
+      name: string;
+      inputSchema: {
+        properties?: Record<string, unknown>;
+        required?: string[];
+        additionalProperties?: boolean;
+      };
+    }>;
+
+    for (const tool of tools) {
+      expect(
+        Object.keys(tool.inputSchema.properties ?? {}).length,
+        `${tool.name} exposes no properties`,
+      ).toBeGreaterThan(0);
+      expect(
+        tool.inputSchema.required ?? [],
+        `${tool.name} exposes no required fields`,
+      ).not.toEqual([]);
+      expect(
+        tool.inputSchema.additionalProperties,
+        `${tool.name} does not reject unknown keys`,
+      ).toBe(false);
+    }
+
+    const archive = tools.find((t) => t.name === 'weather_archive');
+    expect(archive?.inputSchema.required).toEqual(
+      expect.arrayContaining(['latitude', 'longitude', 'start_date', 'end_date']),
+    );
+    const climate = tools.find((t) => t.name === 'climate_projection');
+    expect(climate?.inputSchema.required).toEqual(
+      expect.arrayContaining(['latitude', 'longitude', 'start_date', 'end_date']),
+    );
+  });
+
+  it('keeps an oversized tool response within the character limit', async () => {
+    const client = (mcpServer as unknown as { client: OpenMeteoClient }).client;
+    const length = 20_000;
+    vi.spyOn(client, 'getForecast').mockResolvedValue({
+      latitude: 48.85,
+      longitude: 2.35,
+      elevation: 35,
+      generationtime_ms: 0.1,
+      utc_offset_seconds: 0,
+      hourly: {
+        time: Array.from({ length }, (_, i) => `2026-01-01T${i}:00`),
+        temperature_2m: Array.from({ length }, (_, i) => i / 10),
+      },
+    });
+
+    const acceptBoth = 'application/json, text/event-stream';
+    const initRes = await supertest(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', acceptBoth)
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      });
+    const sessionId = initRes.headers['mcp-session-id'];
+
+    const callRes = await supertest(app)
+      .post('/mcp')
+      .set('mcp-session-id', sessionId)
+      .set('Content-Type', 'application/json')
+      .set('Accept', acceptBoth)
+      .send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'weather_forecast', arguments: { latitude: 48.85, longitude: 2.35 } },
+      });
+
+    const text = callRes.body.result.content[0].text as string;
+    expect(text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    expect(JSON.parse(text).truncated).toBe(true);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ import express from 'express';
 import { z } from 'zod';
 import { OpenMeteoClient } from './client.js';
 import {
+  createAcceptNormalizer,
   createAuthMiddleware,
+  createOriginValidator,
   createRateLimiter,
   generateSessionId,
   getClientIp,
@@ -324,31 +326,15 @@ export class OpenMeteoMCPServer {
       res.status(200).json({ status: 'ok' });
     });
 
-    app.use((req, _res, next) => {
-      const acceptHeader = req.headers.accept;
-      const tokens = acceptHeader
-        ? acceptHeader
-            .split(',')
-            .map((value) => value.trim())
-            .filter(Boolean)
-        : [];
+    app.use(createAcceptNormalizer());
 
-      const normalized = new Set(tokens.map((value) => value.toLowerCase()));
-
-      const ensureHeader = (value: string) => {
-        if (!normalized.has(value)) {
-          tokens.push(value);
-          normalized.add(value);
-        }
-      };
-
-      ensureHeader('application/json');
-      ensureHeader('text/event-stream');
-
-      req.headers.accept = tokens.join(', ');
-
-      next();
-    });
+    // Every guard below must be registered BEFORE the routes it protects:
+    // Express runs middleware in declaration order, so anything mounted after a
+    // route never runs for it. These three previously sat between the DELETE and
+    // POST handlers, leaving GET and DELETE unauthenticated and unthrottled.
+    app.use(createOriginValidator());
+    app.use(createRateLimiter());
+    app.use(createAuthMiddleware());
 
     // GET /mcp — SSE streaming for server-to-client notifications
     app.get('/mcp', async (req, res) => {
@@ -455,9 +441,6 @@ export class OpenMeteoMCPServer {
         }
       }
     });
-
-    app.use(createRateLimiter());
-    app.use(createAuthMiddleware());
 
     app.post('/mcp', async (req, res) => {
       const remoteIp = getClientIp(req);
@@ -580,9 +563,13 @@ export class OpenMeteoMCPServer {
   private startHttpTransport(): void {
     const app = this.buildExpressApp();
     const port = parseInt(process.env.PORT || '3000', 10);
+    // Loopback by default so a local server is not silently exposed on the LAN.
+    // Container images set HOST=0.0.0.0 explicitly, since the container boundary
+    // is what limits reachability there.
+    const host = process.env.HOST || '127.0.0.1';
     app
-      .listen(port, () => {
-        log('info', 'server_start', { transport: 'http', port });
+      .listen(port, host, () => {
+        log('info', 'server_start', { transport: 'http', host, port });
       })
       .on('error', (err) => {
         log('error', 'server_error', { error: err instanceof Error ? err.message : String(err) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import express from 'express';
-import type { z } from 'zod';
+import { z } from 'zod';
 import { OpenMeteoClient } from './client.js';
 import {
   createAuthMiddleware,
@@ -37,7 +37,7 @@ import {
   WEATHER_ARCHIVE_TOOL,
   WEATHER_FORECAST_TOOL,
 } from './tools.js';
-import { truncateResponse } from './truncation.js';
+import { serializeToolResponse } from './truncation.js';
 import {
   type AirQualityParams,
   AirQualityParamsSchema,
@@ -110,11 +110,12 @@ export class OpenMeteoMCPServer {
   // JSON schema), and wraps the handler with logging, response truncation,
   // and MCP-style error results shared across all 17 tools.
   //
-  // registerTool's own generic overloads recurse too deep for TypeScript once
-  // a params schema uses .refine()/.superRefine() (e.g. ArchiveParamsSchema's
-  // date-range check) combined with this project's `strict`+`noUncheckedIndexedAccess`
-  // tsconfig, so the call below goes through an untyped signature; each call
-  // site's `handler` still gets a precise, explicitly-annotated params type.
+  // The schemas arrive here as a common `z.ZodTypeAny` rather than the concrete
+  // per-tool types registerTool's generic overloads expect, so the call below
+  // goes through an untyped signature; each call site's `handler` still gets a
+  // precise, explicitly-annotated params type. Note this cast also silences the
+  // SDK's compile-time check on `inputSchema` — see the ZodEffects handling
+  // below for what that check would otherwise have caught.
   private registerReadOnlyTool(
     server: McpServer,
     meta: ToolDefinition,
@@ -127,21 +128,39 @@ export class OpenMeteoMCPServer {
       cb: unknown,
     ) => void;
 
+    // `.refine()` wraps the object in a ZodEffects, which the SDK cannot
+    // introspect: it would publish an empty `{}` input schema while still
+    // validating strictly, leaving clients with no idea what to send. Publish
+    // the underlying object and re-apply the effects below.
+    const objectSchema = schema instanceof z.ZodEffects ? schema.innerType() : schema;
+
     registerToolUntyped(
       meta.name,
       {
         title: meta.title,
         description: meta.description,
-        inputSchema: schema,
+        inputSchema: objectSchema,
         annotations: meta.annotations,
       },
       async (params: never) => {
         const start = Date.now();
         log('info', 'tool_call', { tool: meta.name, args: params });
 
+        // Cross-field rules (e.g. start_date <= end_date) live in the effects
+        // the SDK never sees, so they are enforced here.
+        const refined = schema.safeParse(params);
+        if (!refined.success) {
+          const message = refined.error.issues.map((issue) => issue.message).join('; ');
+          log('error', 'tool_error', { tool: meta.name, error: message, duration_ms: 0 });
+          return {
+            content: [{ type: 'text' as const, text: `Error: ${message}` }],
+            isError: true,
+          };
+        }
+
         try {
-          const result = await handler(params);
-          const responseText = JSON.stringify(truncateResponse(result), null, 2);
+          const result = await handler(refined.data as never);
+          const responseText = serializeToolResponse(result);
           log('info', 'tool_success', {
             tool: meta.name,
             response_size: responseText.length,

--- a/src/security.ts
+++ b/src/security.ts
@@ -43,6 +43,90 @@ export function createAuthMiddleware() {
 }
 
 /**
+ * Express middleware guarding against DNS rebinding attacks: without it, a page
+ * served from any website can drive a locally bound MCP server through the
+ * victim's browser.
+ *
+ * Requests carrying no `Origin` header — CLI clients, SDK transports, container
+ * probes — pass through untouched. A request that does carry one is browser-issued
+ * and must match the ALLOWED_ORIGINS allow-list (comma-separated), which is empty
+ * by default: no browser is expected to talk to this server unless configured.
+ */
+export function createOriginValidator() {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.headers.origin;
+    if (!origin) {
+      next();
+      return;
+    }
+
+    const allowed = (process.env.ALLOWED_ORIGINS ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    if (allowed.includes(origin)) {
+      next();
+      return;
+    }
+
+    res.status(403).json({
+      jsonrpc: '2.0',
+      error: { code: -32600, message: 'Forbidden: origin not allowed' },
+      id: null,
+    });
+  };
+}
+
+/**
+ * The MCP spec requires clients to accept both application/json and
+ * text/event-stream; clients sending `*\/*` or a single type are otherwise
+ * rejected with a 406. This widens the header on their behalf.
+ *
+ * Crucially it rewrites `rawHeaders` and not just `req.headers`: the SDK hands
+ * the request to Hono's `getRequestListener`, which rebuilds the web-standard
+ * Request from Node's raw header array, so mutating the parsed object alone is
+ * invisible to the transport.
+ */
+export function createAcceptNormalizer() {
+  const required = ['application/json', 'text/event-stream'];
+
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const tokens = (req.headers.accept ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    const present = new Set(tokens.map((value) => value.toLowerCase()));
+
+    for (const value of required) {
+      if (!present.has(value)) {
+        tokens.push(value);
+        present.add(value);
+      }
+    }
+
+    const merged = tokens.join(', ');
+    req.headers.accept = merged;
+
+    // Rebuild rawHeaders with exactly one Accept entry carrying the merged value.
+    const raw = req.rawHeaders;
+    const rebuilt: string[] = [];
+    for (let i = 0; i < raw.length; i += 2) {
+      const key = raw[i];
+      const value = raw[i + 1];
+      if (key === undefined || value === undefined) continue;
+      if (key.toLowerCase() === 'accept') continue;
+      rebuilt.push(key, value);
+    }
+    rebuilt.push('Accept', merged);
+    raw.length = 0;
+    raw.push(...rebuilt);
+
+    next();
+  };
+}
+
+/**
  * Returns a safe, generic error message for HTTP responses.
  * Never expose internal error details (stack traces, connection strings,
  * internal hostnames) to clients.

--- a/src/truncation.test.ts
+++ b/src/truncation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CHARACTER_LIMIT, truncateResponse } from './truncation.js';
+import { CHARACTER_LIMIT, serializeToolResponse, truncateResponse } from './truncation.js';
 
 function makeHourlySeries(length: number) {
   return {
@@ -67,5 +67,27 @@ describe('truncateResponse', () => {
     expect(result.truncated).toBe(true);
     expect(result.results.length).toBeGreaterThan(0);
     expect(result.results.length).toBeLessThan(5000);
+  });
+});
+
+describe('serializeToolResponse', () => {
+  it('keeps the emitted text within the character limit, indentation included', () => {
+    const large = { latitude: 48.85, longitude: 2.35, hourly: makeHourlySeries(20_000) };
+
+    const text = serializeToolResponse(large);
+
+    // The budget applies to what is actually sent to the client, so the
+    // measurement has to account for the pretty-printing whitespace.
+    expect(text.length).toBeLessThanOrEqual(CHARACTER_LIMIT);
+    expect(JSON.parse(text).truncated).toBe(true);
+  });
+
+  it('pretty-prints responses that fit without marking them truncated', () => {
+    const small = { latitude: 48.85, longitude: 2.35, hourly: makeHourlySeries(5) };
+
+    const text = serializeToolResponse(small);
+
+    expect(text).toBe(JSON.stringify(small, null, 2));
+    expect(JSON.parse(text).truncated).toBeUndefined();
   });
 });

--- a/src/truncation.ts
+++ b/src/truncation.ts
@@ -1,6 +1,15 @@
 // Maximum response size in characters before truncation kicks in.
 export const CHARACTER_LIMIT = 25_000;
 
+// Indentation used for every tool response. Truncation must measure the text as
+// it is actually emitted — pretty-printing roughly doubles the character count,
+// so measuring compact JSON here would let responses blow past the limit.
+const JSON_INDENT = 2;
+
+function serialize(value: unknown): string {
+  return JSON.stringify(value, null, JSON_INDENT);
+}
+
 // Object-shaped fields whose values are parallel time-series arrays
 // (e.g. hourly.time, hourly.temperature_2m — same length, same index meaning).
 const TIME_SERIES_KEYS = ['hourly', 'daily', 'minutely_15'] as const;
@@ -30,7 +39,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * if it has no recognized shape to truncate (nothing is guessed at).
  */
 export function truncateResponse(result: unknown): unknown {
-  const originalText = JSON.stringify(result);
+  const originalText = serialize(result);
   if (originalText.length <= CHARACTER_LIMIT || !isPlainObject(result)) {
     return result;
   }
@@ -43,9 +52,12 @@ export function truncateResponse(result: unknown): unknown {
   }
 
   const clone = structuredClone(result) as Record<string, unknown>;
-  let currentText = originalText;
+  // The notice is part of the payload, so every measurement below includes it —
+  // otherwise the appended message pushes the response back over the limit.
+  let candidate = withTruncationNotice(clone, originalText.length);
+  let currentText = serialize(candidate);
 
-  for (let attempt = 0; attempt < 5 && currentText.length > CHARACTER_LIMIT; attempt++) {
+  for (let attempt = 0; attempt < 8 && currentText.length > CHARACTER_LIMIT; attempt++) {
     const ratio = CHARACTER_LIMIT / currentText.length;
     for (const key of seriesKeys) {
       shrinkArraysInPlace(clone[key] as Record<string, unknown>, ratio);
@@ -54,15 +66,35 @@ export function truncateResponse(result: unknown): unknown {
       const arr = clone.results as unknown[];
       clone.results = arr.slice(0, Math.max(1, Math.floor(arr.length * ratio)));
     }
-    currentText = JSON.stringify(clone);
+    candidate = withTruncationNotice(clone, originalText.length);
+    currentText = serialize(candidate);
   }
 
+  return candidate;
+}
+
+function withTruncationNotice(
+  clone: Record<string, unknown>,
+  originalLength: number,
+): Record<string, unknown> {
   return {
     ...clone,
     truncated: true,
+    // Deliberately free of the post-truncation length: the notice sits inside
+    // the payload it would be describing, so that number cannot be known before
+    // the notice itself is serialized.
     truncation_message:
-      `Response truncated from ${originalText.length} to ${currentText.length} characters ` +
-      `to stay within the ${CHARACTER_LIMIT}-character limit. Narrow the request (start_date/` +
-      'end_date, forecast_days, past_days, or fewer variables) to retrieve the full data.',
+      `Response truncated from ${originalLength} characters to stay within the ` +
+      `${CHARACTER_LIMIT}-character limit. Narrow the request (start_date/end_date, ` +
+      'forecast_days, past_days, or fewer variables) to retrieve the full data.',
   };
+}
+
+/**
+ * Serializes a tool result exactly as it is sent to the client, truncating it
+ * first when needed. Single source of truth for the response text, so the size
+ * that truncation measures can never drift from the size actually emitted.
+ */
+export function serializeToolResponse(result: unknown): string {
+  return serialize(truncateResponse(result));
 }


### PR DESCRIPTION
Follow-up to the four MCP audit PRs (#54–#57). Testing the server end to end surfaced two defects introduced by that work and one authentication gap; this PR fixes all three, each with regression coverage written before the fix.

## 1. `weather_archive` and `climate_projection` published an empty input schema

Both carry a `.refine()` for the `start_date <= end_date` rule, which makes the schema a `ZodEffects`. The SDK cannot introspect that type, so it published `{}` as the input schema **while still validating strictly** — the worst combination: a client had no way to learn the parameters, and any guess was rejected with `-32602`.

```
before:  weather_archive  props= 0  required=[]  addProps=undefined
after:   weather_archive  props=16  required=["latitude","longitude","start_date","end_date"]  addProps=false
```

Fixed by publishing the underlying object via `innerType()` and re-applying the effects in the handler, so cross-field rules stay enforced.

Worth noting: TypeScript was flagging this. The `registerToolUntyped` cast added in #57 was attributed to overload recursion, but it was also silencing the SDK's check on `inputSchema`. The comment now says so.

## 2. Truncation overshot its own limit by ~2.5x

`truncateResponse` measured compact JSON while the handler emitted pretty-printed JSON. A 16-day, 20-variable forecast was "truncated" to 24 904 characters and emitted at 61 279 — rejected outright by the client, which is exactly what #56 set out to prevent.

`serializeToolResponse()` is now the single source of truth for the response text, so the measured form cannot drift from the emitted one. The truncation notice is included in the measurement too, since it is part of the payload.

```
same request, after:  24 959 characters, truncated: true, 95 hourly points, all series aligned
```

## 3. Auth and rate limiting never ran on `GET` and `DELETE`

The guards were mounted *after* those two routes. Express runs middleware in declaration order, so they were skipped entirely:

| verb | before | after |
|---|---|---|
| `GET /mcp` | 404 — auth skipped | **401** |
| `DELETE /mcp` | 404 — auth skipped | **401** |
| `POST /mcp` | 401 | **401** |

70 unauthenticated `DELETE`s drew no `429` at all, against 60×401 + 10×429 on `POST`. A caller holding a session id could terminate someone else's session without a key. Session ids are UUIDv4 and cannot be guessed, so this needed a leaked id to exploit — but the API key protected one verb out of three.

Also in this commit:

- **Origin validation** (DNS rebinding). Requests with no `Origin` — CLI clients, SDK transports — are unaffected; a browser-issued one must be in `ALLOWED_ORIGINS`, empty by default.
- **Loopback binding.** `HOST` defaults to `127.0.0.1`.
- **The `Accept` normalizer was dead code.** It mutated `req.headers`, but the SDK hands the request to Hono, which rebuilds it from Node's `rawHeaders` — so `Accept: */*` still got a 406. It now rewrites `rawHeaders`, and `*/*` returns 200.

## ⚠️ Breaking change

The HTTP transport no longer listens on all interfaces by default; set `HOST=0.0.0.0` for remote access. The Docker image sets it, so published ports keep working — verified by building the image and reaching `/health` from the host. The contrapositive was checked too: forcing `HOST=127.0.0.1` in the container makes it unreachable from outside while healthy internally, which is the outage this would have caused unnoticed.

## Verification

- **133 tests** (119 + 14 new), typecheck, `biome ci`, clean build
- Each commit passes tests and typecheck in isolation: 123 → 133 → 133
- Verified against the running server, not just the test suite: 17 tool schemas, date-rule rejection, strict-mode rejection, truncated size, the three verbs under `API_KEY`, Origin 403, `Accept: */*`, binding, and a full Docker round trip

The 119 pre-existing tests all passed against every one of these defects — the new coverage targets what they could not see: the published schema shape of every tool (the old test only checked `weather_forecast`), the size actually emitted, and the auth/origin/Accept behaviour of the HTTP pipeline.

Docs updated to match: the README's remote-deployment example was unreachable under the new default, and neither README nor CLAUDE.md mentioned the response cap. CLAUDE.md now records the three traps, none of which are apparent from reading the code.